### PR TITLE
Add changelog, add unicode_pm option, documentation, and tests.

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -1,0 +1,5 @@
+0.14.0 (2023-06-17)
+-------------------
+
+* Add Changelog
+* Add ``unicode_pm`` option with documentation and tests.

--- a/docs/source/Formatting Options.rst
+++ b/docs/source/Formatting Options.rst
@@ -400,8 +400,8 @@ according to the options below.
 >>> print(sform(123.456, 0.789))
 123.456 +/- 0.789
 
-Plus Minus Whitespace
----------------------
+Plus Minus Symbol Formatting
+----------------------------
 
 The user can enable (default) or disable white space around the plus/minus
 symbol when formatting value/uncertainties.
@@ -412,6 +412,13 @@ symbol when formatting value/uncertainties.
 >>> sform = Formatter(unc_pm_whitespace=False)
 >>> print(sform(123.456, 0.789))
 123.456+/-0.789
+
+The user can also replace the ``'+/-'`` symbol with a unicode ``'±'``
+symbol using the ``unicode_pm`` option.
+
+>>> sform = Formatter(unicode_pm=True)
+>>> print(sform(123.456, 0.789))
+123.456 ± 0.789
 
 Bracket Uncertainty
 -------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@
    Supported Prefixes
    api
    examples
+   project
 
 Indices and tables
 ==================

--- a/docs/source/project.rst
+++ b/docs/source/project.rst
@@ -1,0 +1,7 @@
+Project
+#######
+
+Changelog
+=========
+
+.. include:: ../../Changelog.rst

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -132,6 +132,7 @@ The global default settings can be viewed using
  'bracket_unc': False,
  'val_unc_match_widths': False,
  'bracket_unc_remove_seps': False,
+ 'unicode_pm': False,
  'unc_pm_whitespace': True}
 
 The global default settings can be modified using
@@ -168,6 +169,7 @@ applied to setting global default settings.
  'bracket_unc': False,
  'val_unc_match_widths': False,
  'bracket_unc_remove_seps': False,
+ 'unicode_pm': False,
  'unc_pm_whitespace': True}
 
 The global default settings can be reset to the :mod:`sciform` defaults

--- a/src/sciform/__init__.py
+++ b/src/sciform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.13.2"
+__version__ = "0.14.0"
 
 from sciform.formatter import Formatter
 from sciform.float_formatting import sfloat, vufloat

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -20,7 +20,7 @@ class FormatOptions:
     lower_separator: LowerGroupingSeparators
     round_mode: RoundMode
     precision: Union[int, type(AutoPrec)]
-    exp_mode: ExpMode  # TODO: rename to exp_mode
+    exp_mode: ExpMode
     exp: Union[int, type(AutoExp)]
     capitalize: bool
     percent: bool
@@ -31,6 +31,7 @@ class FormatOptions:
     bracket_unc: bool
     val_unc_match_widths: bool
     bracket_unc_remove_seps: bool
+    unicode_pm: bool
     unc_pm_whitespace: bool
 
     def __post_init__(self):
@@ -100,6 +101,7 @@ class FormatOptions:
             bracket_unc: bool = None,
             val_unc_match_widths: bool = None,
             bracket_unc_remove_seps: bool = None,
+            unicode_pm: bool = None,
             unc_pm_whitespace: bool = None
     ):
         if defaults is None:
@@ -147,6 +149,8 @@ class FormatOptions:
             val_unc_match_widths = defaults.val_unc_match_widths
         if bracket_unc_remove_seps is None:
             bracket_unc_remove_seps = defaults.bracket_unc_remove_seps
+        if unicode_pm is None:
+            unicode_pm = defaults.unicode_pm
         if unc_pm_whitespace is None:
             unc_pm_whitespace = defaults.unc_pm_whitespace
 
@@ -183,6 +187,7 @@ class FormatOptions:
             bracket_unc=bracket_unc,
             val_unc_match_widths=val_unc_match_widths,
             bracket_unc_remove_seps=bracket_unc_remove_seps,
+            unicode_pm=unicode_pm,
             unc_pm_whitespace=unc_pm_whitespace
         )
 
@@ -343,6 +348,7 @@ DEFAULT_PKG_OPTIONS = FormatOptions(
     bracket_unc=False,
     val_unc_match_widths=False,
     bracket_unc_remove_seps=False,
+    unicode_pm=False,
     unc_pm_whitespace=True
 )
 
@@ -385,6 +391,7 @@ def set_global_defaults(
         bracket_unc=None,
         val_unc_match_widths=None,
         bracket_unc_remove_seps=None,
+        unicode_pm=None,
         unc_pm_whitespace=None
 ):
     """
@@ -419,6 +426,7 @@ def set_global_defaults(
         bracket_unc=bracket_unc,
         val_unc_match_widths=val_unc_match_widths,
         bracket_unc_remove_seps=bracket_unc_remove_seps,
+        unicode_pm=unicode_pm,
         unc_pm_whitespace=unc_pm_whitespace
     )
     DEFAULT_GLOBAL_OPTIONS = new_default_options
@@ -501,6 +509,7 @@ class GlobalDefaultsContext:
             bracket_unc: bool = None,
             val_unc_match_widths: bool = None,
             bracket_unc_remove_seps: bool = None,
+            unicode_pm: bool = None,
             unc_pm_whitespace: bool = None
     ):
         self.options = FormatOptions.make(
@@ -526,6 +535,7 @@ class GlobalDefaultsContext:
             bracket_unc=bracket_unc,
             val_unc_match_widths=val_unc_match_widths,
             bracket_unc_remove_seps=bracket_unc_remove_seps,
+            unicode_pm=unicode_pm,
             unc_pm_whitespace=unc_pm_whitespace
         )
         self.initial_global_defaults = None

--- a/src/sciform/formatter.py
+++ b/src/sciform/formatter.py
@@ -112,6 +112,8 @@ class Formatter:
       symbols should be removed from the uncertainty when using bracket
       uncertainty mode. E.g. expressing ``123.4 +/- 2.3`` as
       ``123.4(23)`` instead of ``123.4(2.3)``.
+    :param unicode_pm: ``bool`` indicating if the '+/-' separator should
+      be replaced with the unicode plus minus symbol '±'.
     :param unc_pm_whitespace: ``bool`` indicating if there should be
       whitespace surrounding the ``'+/-'`` symbols when formatting. E.g.
       ``123.4+/-2.3`` compared to ``123.4 +/- 2.3``.
@@ -140,6 +142,7 @@ class Formatter:
             bracket_unc: bool = None,
             val_unc_match_widths: bool = None,
             bracket_unc_remove_seps: bool = None,
+            unicode_pm: bool = None,
             unc_pm_whitespace: bool = None
     ):
         self.options = FormatOptions.make(
@@ -165,6 +168,7 @@ class Formatter:
             bracket_unc=bracket_unc,
             val_unc_match_widths=val_unc_match_widths,
             bracket_unc_remove_seps=bracket_unc_remove_seps,
+            unicode_pm=unicode_pm,
             unc_pm_whitespace=unc_pm_whitespace
         )
 
@@ -198,6 +202,7 @@ class Formatter:
                    bracket_unc=options.bracket_unc,
                    val_unc_match_widths=options.val_unc_match_widths,
                    bracket_unc_remove_seps=options.bracket_unc_remove_seps,
+                   unicode_pm=options.unicode_pm,
                    unc_pm_whitespace=options.unc_pm_whitespace)
 
     @classmethod

--- a/src/sciform/formatting.py
+++ b/src/sciform/formatting.py
@@ -240,10 +240,14 @@ def format_val_unc(val: float, unc: float, options: FormatOptions):
         exp_str = unc_match.group('exp_str')
 
     if not options.bracket_unc:
-        if options.unc_pm_whitespace:
-            val_unc_str = f'{val_str} +/- {unc_str}'
+        if not options.unicode_pm:
+            pm_symb = '+/-'
         else:
-            val_unc_str = f'{val_str}+/-{unc_str}'
+            pm_symb = '±'
+        if options.unc_pm_whitespace:
+            val_unc_str = f'{val_str} {pm_symb} {unc_str}'
+        else:
+            val_unc_str = f'{val_str}{pm_symb}{unc_str}'
     else:
         unc_str = unc_str.lstrip('0.,_ ')
         if options.bracket_unc_remove_seps:

--- a/tests/test_val_unc_formatter.py
+++ b/tests/test_val_unc_formatter.py
@@ -63,3 +63,13 @@ class TestFormatting(unittest.TestCase):
         }
 
         self.do_test_case_dict(cases_dict)
+
+    def test_unicode_pm(self):
+        cases_dict = {
+            (123.456, 0.789):
+                {
+                    Formatter(unicode_pm=True): '123.456 ± 0.789'
+                }
+        }
+
+        self.do_test_case_dict(cases_dict)


### PR DESCRIPTION
Add options for unicode plus/minus symbol along with corresponding documentation and tests. See issue https://github.com/jagerber48/sciform/issues/1.

```
>>> sform = Formatter(unicode_pm=True)
>>> print(sform(123.456, 0.789))
123.456 ± 0.789
```

Also include changelog in documentation.

