### PR TITLE
Feature/user format options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+0.23.0 (2023-??-??)
+-------------------
+
+* **[BREAKING]** Users now construct ``FormatOptions`` objects which
+  they pass into ``Formatter`` objects and global configuration
+  functions.
+  ``Formatter`` and global configuration functions no longer accept bare
+  keyword arguments to indicate formatting options.
+* Change ``pyproject.toml`` description
+
+
 0.22.2 (2023-07-27)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@
   functions.
   ``Formatter`` and global configuration functions no longer accept bare
   keyword arguments to indicate formatting options.
+* **[BREAKING]** ``Formatter`` now resolves unspecified format options
+  from the global defaults at format time instead of initialization
+  time.
+  This is more similar to the previous behavior for ``SciNum`` and
+  ``SciNumUnc``.
 * Change ``pyproject.toml`` description
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.23.0 (2023-??-??)
+0.23.0 (2023-07-29)
 -------------------
 
 * **[BREAKING]** Users now construct ``FormatOptions`` objects which

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,11 @@
   functions.
   ``Formatter`` and global configuration functions no longer accept bare
   keyword arguments to indicate formatting options.
-* **[BREAKING]** ``Formatter`` now resolves unspecified format options
+* **[BREAKING]** ``Formatter`` now resolves un-filled format options
   from the global defaults at format time instead of initialization
   time.
-  This is more similar to the previous behavior for ``SciNum`` and
-  ``SciNumUnc``.
+  This is consistent with the previous behavior for ``SciNum`` and
+  ``SciNumUnc`` objects.
 * Change ``pyproject.toml`` description
 
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,6 @@ Usage
 
 ``sciform`` provides a wide variety of formatting options.
 These options are configured using the ``FormatOptions`` object.
-
 Users can construct ``FormatOptions`` objects and pass them into
 ``Formatter`` objects which can then be used to format numbers into
 strings according to the selected options.

--- a/README.rst
+++ b/README.rst
@@ -72,11 +72,11 @@ strings according to the selected options.
 123.5e+03
 
 For brevity, the user may consider abbreviating ``FormatOptions`` as
-``FO``.
+``Fo``.
 
->>> from sciform import FormatOptions as FO
+>>> from sciform import FormatOptions as Fo
 >>> from sciform import Formatter, RoundMode, GroupingSeparator, ExpMode
->>> sform = Formatter(FO(round_mode=RoundMode.PREC,
+>>> sform = Formatter(Fo(round_mode=RoundMode.PREC,
 ...                      precision=6,
 ...                      upper_separator=GroupingSeparator.SPACE,
 ...                      lower_separator=GroupingSeparator.SPACE))
@@ -97,12 +97,12 @@ to format pairs of numbers as value/uncertainty pairs.
 This can be done by passing two numbers into a ``Formatter`` call or by
 using the ``SciNumUnc`` object.
 
->>> sform = Formatter(FO(precision=2,
+>>> sform = Formatter(Fo(precision=2,
 ...                      upper_separator=GroupingSeparator.SPACE,
 ...                      lower_separator=GroupingSeparator.SPACE))
 >>> print(sform(123456.654321, 0.0034))
 123 456.654 3 +/- 0.003 4
->>> sform = Formatter(FO(precision=4,
+>>> sform = Formatter(Fo(precision=4,
 ...                      exp_mode=ExpMode.ENGINEERING))
 >>> print(sform(123456.654321, 0.0034))
 (123.456654321 +/- 0.000003400)e+03

--- a/README.rst
+++ b/README.rst
@@ -48,39 +48,62 @@ about it!
 Usage
 =====
 
-``sciform`` provides two primary methods for formatting numbers into
-scientific formatted strings.
-The first is via the ``Formatter`` object and the second is using string
-formatting and the custom FSML with the ``SciNum`` object.
+``sciform`` provides a wide variety of formatting options.
+These options are configured using the ``FormatOptions`` object.
 
->>> from sciform import Formatter, RoundMode, GroupingSeparator, ExpMode
->>> sform = Formatter(round_mode=RoundMode.PREC,
-...                   precision=6,
-...                   upper_separator=GroupingSeparator.SPACE,
-...                   lower_separator=GroupingSeparator.SPACE)
+Users can construct ``FormatOptions`` objects and pass them into
+``Formatter`` objects which can then be used to format numbers into
+strings according to the selected options.
+
+>>> from sciform import (FormatOptions, Formatter, RoundMode,
+...                      GroupingSeparator, ExpMode)
+>>> sform = Formatter(FormatOptions(
+...             round_mode=RoundMode.PREC,
+...             precision=6,
+...             upper_separator=GroupingSeparator.SPACE,
+...             lower_separator=GroupingSeparator.SPACE))
 >>> print(sform(51413.14159265359))
 51 413.141 593
->>> sform = Formatter(round_mode=RoundMode.SIG_FIG,
-...                   precision=4,
-...                   exp_mode=ExpMode.ENGINEERING)
+>>> sform = Formatter(FormatOptions(
+...             round_mode=RoundMode.SIG_FIG,
+...             precision=4,
+...             exp_mode=ExpMode.ENGINEERING))
 >>> print(sform(123456.78))
 123.5e+03
+
+For brevity, the user may consider abbreviating ``FormatOptions`` as
+``FO``.
+
+>>> from sciform import FormatOptions as FO
+>>> from sciform import Formatter, RoundMode, GroupingSeparator, ExpMode
+>>> sform = Formatter(FO(round_mode=RoundMode.PREC,
+...                      precision=6,
+...                      upper_separator=GroupingSeparator.SPACE,
+...                      lower_separator=GroupingSeparator.SPACE))
+>>> print(sform(51413.14159265359))
+51 413.141 593
+
+Users can also format numbers by constructing ``SciNum`` objects and
+using string formatting to format the ``SciNum`` instances according
+to a custom FSML.
 
 >>> from sciform import SciNum
 >>> num = SciNum(123456)
 >>> print(f'{num:_!2f}')
 120_000
 
-``sciform`` can also be used to format pairs of value/uncertainty
-numbers using the ``Formatter`` or ``SciNumUnc`` objects.
+In addition to formatting individual numbers, ``sciform`` can be used
+to format pairs of numbers as value/uncertainty pairs.
+This can be done by passing two numbers into a ``Formatter`` call or by
+using the ``SciNumUnc`` object.
 
->>> sform = Formatter(precision=2,
-...                   upper_separator=GroupingSeparator.SPACE,
-...                   lower_separator=GroupingSeparator.SPACE)
+>>> sform = Formatter(FO(precision=2,
+...                      upper_separator=GroupingSeparator.SPACE,
+...                      lower_separator=GroupingSeparator.SPACE))
 >>> print(sform(123456.654321, 0.0034))
 123 456.654 3 +/- 0.003 4
->>> sform = Formatter(precision=4,
-...                   exp_mode=ExpMode.ENGINEERING)
+>>> sform = Formatter(FO(precision=4,
+...                      exp_mode=ExpMode.ENGINEERING))
 >>> print(sform(123456.654321, 0.0034))
 (123.456654321 +/- 0.000003400)e+03
 
@@ -88,6 +111,8 @@ numbers using the ``Formatter`` or ``SciNumUnc`` objects.
 >>> num = SciNumUnc(123456.654321, 0.0034)
 >>> print(f'{num:_!2f}')
 123_456.6543 +/- 0.0034
+>>> print(f'{num:_!2f()}')
+123_456.6543(34)
 
 
 ================

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,8 @@ API
 Formatting
 ==========
 
+.. autoclass:: FormatOptions()
+
 .. autoclass:: Formatter()
 
 .. autoclass:: SciNum()

--- a/docs/source/exp replacement.rst
+++ b/docs/source/exp replacement.rst
@@ -148,10 +148,11 @@ For this reason, the usage of this notation is sometimes discouraged.
 Note that it is possible, using the ``extra_parts_per_forms`` option to
 override the standard mappings listed above.
 
+>>> from sciform import FormatOptions as Fo
 >>> from sciform import Formatter, ExpMode
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-...                   parts_per_exp=True,
-...                   extra_parts_per_forms={-9: None, -12: 'ppb'})
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING,
+...                      parts_per_exp=True,
+...                      extra_parts_per_forms={-9: None, -12: 'ppb'}))
 >>> print(sform(33e-9))
 33e-09
 >>> print(sform(33e-12))

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -33,8 +33,9 @@ Fixed Point
 Fixed point notation is standard notation in which a number is displayed
 directly with no extra exponent.
 
+>>> from sciform import FormatOptions as Fo
 >>> from sciform import Formatter, ExpMode, RoundMode
->>> sform = Formatter(exp_mode=ExpMode.FIXEDPOINT)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.FIXEDPOINT))
 >>> print(sform(123.456))
 123.456
 
@@ -47,7 +48,7 @@ Scientific notation is used to display base-10 decimal numbers.
 In scientific notation, the exponent is uniquely chosen so that the
 mantissa ``m`` satisfies ``1 <= m < 10``.
 
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC))
 >>> print(sform(123.456))
 1.23456e+02
 
@@ -76,7 +77,7 @@ Here it may be more convenient to display the number with an exponent of
 to an exponent of 8 which would be chosen for standard scientific
 notation.
 
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING))
 >>> print(sform(123.456))
 123.456e+00
 
@@ -89,7 +90,7 @@ Shifted engineering notation is the same as engineering notation except
 the exponent is chosen so that the mantissa ``m`` satisfies
 ``0.1 <= m < 100``.
 
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING_SHIFTED)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING_SHIFTED))
 >>> print(sform(123.456))
 0.123456e+03
 
@@ -101,7 +102,7 @@ Binary
 Binary formatting can be chosen to display a number in scientific
 notation in base-2.
 
->>> sform = Formatter(exp_mode=ExpMode.BINARY)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.BINARY))
 >>> print(sform(256))
 1b+08
 
@@ -122,7 +123,7 @@ The mantissa ``m`` satisfies ``1 <= m < 1024``.
 Binary formatting can be chosen to display a number in scientific
 notation in base-2.
 
->>> sform = Formatter(exp_mode=ExpMode.BINARY_IEC)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.BINARY_IEC))
 >>> print(sform(2048))
 2b+10
 
@@ -135,8 +136,8 @@ If a fixed exponent is requested for engineering, shifted engineering,
 or binary IEC mode, then the requested exponent is rounded down to the
 nearest multiple of 3 or 10.
 
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC,
-...                   exp=3)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC,
+...                      exp=3))
 >>> print(sform(123.456))
 0.123456e+03
 
@@ -160,18 +161,18 @@ Furthermore, it is possible to customize :class:`Formatter`
 objects or the global configuration settings to map additional
 translations, in addition to those provided by default.
 
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-...                   prefix_exp=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING,
+...                      prefix_exp=True))
 >>> print(sform(4242.13))
 4.24213 k
->>> sform = Formatter(exp_mode=ExpMode.BINARY_IEC,
-...                   round_mode=RoundMode.SIG_FIG,
-...                   precision=4,
-...                   prefix_exp=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.BINARY_IEC,
+...                      round_mode=RoundMode.SIG_FIG,
+...                      precision=4,
+...                      prefix_exp=True))
 >>> print(sform(1300))
 1.270 Ki
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-...                   parts_per_exp=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING,
+...                      parts_per_exp=True))
 >>> print(sform(12.3e-6))
 12.3 ppm
 
@@ -191,22 +192,22 @@ corresponding to translated strings.
 The entries in these dictionaries overwrite any default translation
 mappings.
 
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC,
-...                   prefix_exp=True,
-...                   extra_si_prefixes={-2: 'c'})
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC,
+...                      prefix_exp=True,
+...                      extra_si_prefixes={-2: 'c'}))
 >>> print(sform(3e-2))
 3 c
 
 Passing ``None`` for the value for a corresponding exponent value will
 force that exponent to not be translated.
 
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-...                   parts_per_exp=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING,
+...                      parts_per_exp=True))
 >>> print(sform(3e-9))
 3 ppb
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-...                   parts_per_exp=True,
-...                   extra_parts_per_forms={-9: None})
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING,
+...                      parts_per_exp=True,
+...                      extra_parts_per_forms={-9: None}))
 >>> print(sform(3e-9))
 3e-09
 
@@ -221,14 +222,14 @@ engineering notation.
 However, they can be easily be included using the ``add_c_prefix`` and
 ``add_small_si_prefixes`` options.
 
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC,
-...                   prefix_exp=True,
-...                   add_c_prefix=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC,
+...                      prefix_exp=True,
+...                      add_c_prefix=True))
 >>> print(sform(0.025))
 2.5 c
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC,
-...                   prefix_exp=True,
-...                   add_small_si_prefixes=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC,
+...                      prefix_exp=True,
+...                      add_small_si_prefixes=True))
 >>> print(sform(25))
 2.5 da
 
@@ -237,9 +238,9 @@ the ``add_ppth_form`` option.
 Note that ``ppth`` is not a standard notation for "parts-per-thousand",
 but it is one that the author has found useful.
 
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-...                   parts_per_exp=True,
-...                   add_ppth_form=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING,
+...                      parts_per_exp=True,
+...                      add_ppth_form=True))
 >>> print(sform(12.3e-3))
 12.3 ppth
 
@@ -289,9 +290,9 @@ a number was rounded to (or "how many significant figures a number has")
 just by looking at the resulting string.
 
 >>> from sciform import RoundMode
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-...                   round_mode=RoundMode.SIG_FIG,
-...                   precision=4)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING,
+...                      round_mode=RoundMode.SIG_FIG,
+...                      precision=4))
 >>> print(sform(12345.678))
 12.35e+03
 
@@ -311,18 +312,18 @@ Much of the Python built-in string formatting mini-language is based on
 precision presentation.
 
 >>> from sciform import RoundMode
->>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-...                   round_mode=RoundMode.PREC,
-...                   precision=4)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.ENGINEERING,
+...                      round_mode=RoundMode.PREC,
+...                      precision=4))
 >>> print(sform(12345.678))
 12.3457e+03
 
 For precision rounding, ``precision`` can be any integer.
 
 >>> from sciform import RoundMode
->>> sform = Formatter(exp_mode=ExpMode.FIXEDPOINT,
-...                   round_mode=RoundMode.PREC,
-...                   precision=-2)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.FIXEDPOINT,
+...                      round_mode=RoundMode.PREC,
+...                      precision=-2))
 >>> print(sform(12345.678))
 12300
 
@@ -346,14 +347,14 @@ Note that the upper separator character must be different than the
 decimal separator.
 
 >>> from sciform import GroupingSeparator
->>> sform = Formatter(upper_separator=GroupingSeparator.COMMA)
+>>> sform = Formatter(Fo(upper_separator=GroupingSeparator.COMMA))
 >>> print(sform(12345678.987))
 12,345,678.987
 
 >>> from sciform import GroupingSeparator
->>> sform = Formatter(upper_separator=GroupingSeparator.SPACE,
+>>> sform = Formatter(Fo(upper_separator=GroupingSeparator.SPACE,
 ...                   decimal_separator=GroupingSeparator.COMMA,
-...                   lower_separator=GroupingSeparator.UNDERSCORE)
+...                   lower_separator=GroupingSeparator.UNDERSCORE))
 >>> print(sform(1234567.7654321))
 1 234 567,765_432_1
 
@@ -379,13 +380,13 @@ including a ``'+'`` symbol.
 Note that ``0`` is always considered positive.
 
 >>> from sciform import SignMode
->>> sform = Formatter(sign_mode=SignMode.NEGATIVE)
+>>> sform = Formatter(Fo(sign_mode=SignMode.NEGATIVE))
 >>> print(sform(42))
 42
->>> sform = Formatter(sign_mode=SignMode.ALWAYS)
+>>> sform = Formatter(Fo(sign_mode=SignMode.ALWAYS))
 >>> print(sform(42))
 +42
->>> sform = Formatter(sign_mode=SignMode.SPACE)
+>>> sform = Formatter(Fo(sign_mode=SignMode.SPACE))
 >>> print(sform(42))
  42
 
@@ -394,12 +395,12 @@ Capitalization
 
 The capitalization of the exponent character can be controlled
 
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC,
-...                   capitalize=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC,
+...                   capitalize=True))
 >>> print(sform(42))
 4.2E+01
->>> sform = Formatter(exp_mode=ExpMode.BINARY,
-...                   capitalize=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.BINARY,
+...                   capitalize=True))
 >>> print(sform(1024))
 1B+10
 
@@ -427,8 +428,8 @@ E.g. ``top_dig_place=4`` indicates fill characters should be added up
 to the 10\ :sup:`4` (ten-thousands) place.
 
 >>> from sciform import FillMode
->>> sform = Formatter(fill_mode=FillMode.ZERO,
-...                   top_dig_place=4)
+>>> sform = Formatter(Fo(fill_mode=FillMode.ZERO,
+...                      top_dig_place=4))
 >>> print(sform(42))
 00042
 
@@ -442,9 +443,9 @@ This flag is only valid for fixed point exponent mode.
 In this case, the number is multipled by 100 and a % symbols is
 appended to the end of the formatted string.
 
->>> sform = Formatter(round_mode=RoundMode.SIG_FIG,
-...                   precision=3,
-...                   percent=True)
+>>> sform = Formatter(Fo(round_mode=RoundMode.SIG_FIG,
+...                      precision=3,
+...                      percent=True))
 >>> print(sform(0.12345))
 12.3%
 >>> print(sform(0.12345, 0.001))
@@ -458,8 +459,8 @@ Superscript Exponent Format
 The ``superscript_exp`` option can be chosen to present exponents in
 standard superscript notation as opposed to e.g. ``e+02`` notation.
 
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC,
-...                   superscript_exp=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC,
+...                      superscript_exp=True))
 >>> print(sform(789))
 7.89×10²
 
@@ -471,15 +472,15 @@ Latex Format
 The ``latex`` option can be chosen to convert strings into latex
 parseable codes.
 
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC,
-...                   exp=-1,
-...                   upper_separator=GroupingSeparator.UNDERSCORE,
-...                   latex=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC,
+...                      exp=-1,
+...                      upper_separator=GroupingSeparator.UNDERSCORE,
+...                      latex=True))
 >>> print(sform(12345))
 123\_450\times 10^{-1}
->>> sform = Formatter(lower_separator=GroupingSeparator.UNDERSCORE,
-...                   percent=True,
-...                   latex=True)
+>>> sform = Formatter(Fo(lower_separator=GroupingSeparator.UNDERSCORE,
+...                      percent=True,
+...                      latex=True))
 >>> print(sform(0.12345678, 0.00000255))
 \left(12.345\_678 \pm 0.000\_255\right)\%
 
@@ -508,9 +509,9 @@ However, if ``nan_inf_exp=True`` (default ``False``), then, for
 scientific, engineering, and binary exponent modes, these will instead
 be formatted as, e.g. ``'(nan)e+00'``.
 
->>> sform = Formatter(exp_mode=ExpMode.SCIENTIFIC,
-...                   nan_inf_exp=True,
-...                   capitalize=True)
+>>> sform = Formatter(Fo(exp_mode=ExpMode.SCIENTIFIC,
+...                      nan_inf_exp=True,
+...                      capitalize=True))
 >>> print(sform(float('-inf')))
 (-INF)E+00
 
@@ -569,9 +570,9 @@ formatting value/uncertainty pairs by using significant figure rounding
 mode with :class:`AutoPrec` precision and the ``pdg_sig_figs`` flag.
 
 >>> from sciform import AutoPrec
->>> sform = Formatter(round_mode=RoundMode.SIG_FIG,
-...                   precision=AutoPrec,
-...                   pdg_sig_figs=True)
+>>> sform = Formatter(Fo(round_mode=RoundMode.SIG_FIG,
+...                      precision=AutoPrec,
+...                      pdg_sig_figs=True))
 >>> print(sform(1, 0.0123))
 1.000 +/- 0.012
 >>> print(sform(1, 0.0483))
@@ -588,14 +589,14 @@ symbol when formatting value/uncertainties.
 >>> sform = Formatter()
 >>> print(sform(123.456, 0.789))
 123.456 +/- 0.789
->>> sform = Formatter(unc_pm_whitespace=False)
+>>> sform = Formatter(Fo(unc_pm_whitespace=False))
 >>> print(sform(123.456, 0.789))
 123.456+/-0.789
 
 The user can also replace the ``'+/-'`` symbol with a unicode ``'±'``
 symbol using the ``unicode_pm`` option.
 
->>> sform = Formatter(unicode_pm=True)
+>>> sform = Formatter(Fo(unicode_pm=True))
 >>> print(sform(123.456, 0.789))
 123.456 ± 0.789
 
@@ -616,19 +617,19 @@ We call this format "bracket uncertainty" mode.
 :mod:`sciform` provides this functionality via the ``bracket_unc``
 option:
 
->>> sform = Formatter(bracket_unc=True)
+>>> sform = Formatter(Fo(bracket_unc=True))
 >>> print(sform(123.456, 0.789))
 123.456(789)
 
 Or with other options:
 
->>> sform = Formatter(precision=2,
-...                   bracket_unc=True)
+>>> sform = Formatter(Fo(precision=2,
+...                      bracket_unc=True))
 >>> print(sform(123.456, 0.789))
 123.46(79)
->>> sform = Formatter(precision=2,
-...                   exp_mode=ExpMode.SCIENTIFIC,
-...                   bracket_unc=True)
+>>> sform = Formatter(Fo(precision=2,
+...                      exp_mode=ExpMode.SCIENTIFIC,
+...                      bracket_unc=True))
 >>> print(sform(123.456, 0.789))
 (1.2346(79))e+02
 
@@ -651,30 +652,30 @@ parentheses.
 
 :mod:`sciform` allows the user to optionally remove the decimal symbol
 
->>> sform = Formatter(bracket_unc=True,
-...                   bracket_unc_remove_seps=False)
+>>> sform = Formatter(Fo(bracket_unc=True,
+...                      bracket_unc_remove_seps=False))
 >>> print(sform(18.4, 2.1))
 18.4(2.1)
->>> sform = Formatter(bracket_unc=True,
-...                   bracket_unc_remove_seps=True)
+>>> sform = Formatter(Fo(bracket_unc=True,
+...                      bracket_unc_remove_seps=True))
 >>> print(sform(18.4, 2.1))
 18.4(21)
 
 Note that the ``bracket_unc_remove_seps`` removes *all* separator
 symbols from the uncertainty in the brackets.
 
->>> sform = Formatter(upper_separator=GroupingSeparator.POINT,
-...                   decimal_separator=GroupingSeparator.COMMA,
-...                   lower_separator=GroupingSeparator.UNDERSCORE,
-...                   bracket_unc=True,
-...                   bracket_unc_remove_seps=False)
+>>> sform = Formatter(Fo(upper_separator=GroupingSeparator.POINT,
+...                      decimal_separator=GroupingSeparator.COMMA,
+...                      lower_separator=GroupingSeparator.UNDERSCORE,
+...                      bracket_unc=True,
+...                      bracket_unc_remove_seps=False))
 >>> print(sform(987654, 1234.4321))
 987.654,000_0(1.234,432_1)
->>> sform = Formatter(upper_separator=GroupingSeparator.POINT,
-...                   decimal_separator=GroupingSeparator.COMMA,
-...                   lower_separator=GroupingSeparator.UNDERSCORE,
-...                   bracket_unc=True,
-...                   bracket_unc_remove_seps=True)
+>>> sform = Formatter(Fo(upper_separator=GroupingSeparator.POINT,
+...                      decimal_separator=GroupingSeparator.COMMA,
+...                      lower_separator=GroupingSeparator.UNDERSCORE,
+...                      bracket_unc=True,
+...                      bracket_unc_remove_seps=True))
 >>> print(sform(987654, 1234.4321))
 987.654,000_0(12344321)
 
@@ -697,13 +698,13 @@ digit of the value, and (3) the most significant digit of the
 uncertainty.
 This feature is accessed with the ``val_unc_match_widths`` option.
 
->>> sform = Formatter(fill_mode=FillMode.ZERO,
-...                   top_dig_place=2,
-...                   val_unc_match_widths=False)
+>>> sform = Formatter(Fo(fill_mode=FillMode.ZERO,
+...                      top_dig_place=2,
+...                      val_unc_match_widths=False))
 >>> print(sform(12345, 1.23))
 12345.00 +/- 001.23
->>> sform = Formatter(fill_mode=FillMode.ZERO,
-...                   top_dig_place=2,
-...                   val_unc_match_widths=True)
+>>> sform = Formatter(Fo(fill_mode=FillMode.ZERO,
+...                      top_dig_place=2,
+...                      val_unc_match_widths=True))
 >>> print(sform(12345, 1.23))
 12345.00 +/- 00001.23

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -157,7 +157,7 @@ parts-per identifiers and binary exponent strings can be replaced with
 IEC prefixes.
 See :ref:`exp_replacements` for all default supported
 replacements.
-Furthermore, it is possible to customize :class:`Formatter`
+Furthermore, it is possible to customize :class:`FormatOptions`
 objects or the global configuration settings to map additional
 translations, in addition to those provided by default.
 
@@ -267,7 +267,7 @@ passing ``precision=AutoPrec``.
 This is the default value in the global configuration.
 
 If the number to be formatted is passed in as a :class:`float` (either
-to the :class:`Formatter`, :class:`SciNum`, or :class:`SciNumUnc`),
+to a :class:`Formatter`, :class:`SciNum`, or :class:`SciNumUnc`),
 then, if no precision or number of significant figures is supplied, the
 decimal digits of the :class:`float` are truncated to the minimum number
 of digits necessary for round-tripping.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,6 +14,27 @@ using string formatting and the
 :ref:`Format Specification Mini Language (FSML) <fsml>` with the
 :class:`SciNum` or :class:`SciNumUnc` objects.
 
+FormatOptions
+-------------
+
+``sciform`` formatting options can be configured using a
+:class:`FormatOptions` object.
+See :class:`FormatOptions` for a complete list of
+keyword arguments used to construct :class:`FormatOptions` and see
+:ref:`formatting_options` for more details on the different options.
+
+When constructing a :class:`FormatOptions` object, it is not necessary
+to provide input for all options.
+There are two mechanisms for filling of any un-supplied options.
+First, during initialization, the user can pass in another
+:class:`FormatOptions` instance as a ``template``.
+In this case any populated options for the ``template`` will be used to
+populate corresponding unpopulated options for the new
+:class:`FormatOptions`.
+Second, at format time any remaining unfilled options will be populated
+with the global default options. See :ref:`global_config` for details
+about how to view and modify the global default options.
+
 Formatter
 ---------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -40,8 +40,8 @@ Formatter
 
 The :class:`Formatter` object is initialized and configured using a
 :class:`FormatOptions` object which contains the formatting settings.
-The :class:`FormatOptions` object is then called with number and returns
-a corresponding formatted string.
+The :class:`FormatOptions` object is then called with a number and
+returns a corresponding formatted string.
 Note that global default options are used to populate unfilled options
 at formatting time.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -133,11 +133,11 @@ Global Configuration
 It is possible to modify the global default configuration for
 :mod:`sciform` to avoid repetition of verbose configuration options or
 format specification strings.
-When the user creates a :class:`Formatter` object or formats a string
-using the :ref:`FSML <fsml>`, they typically do not specify settings for
-all available options.
+When the user creates a :class:`FormatOptions` object or formats a
+string using the :ref:`FSML <fsml>`, they typically do not specify
+settings for all available options.
 In these cases, the unspecified options resolve their values from the
-global default settings.
+global default settings at format time.
 
 The global default settings can be viewed using
 :func:`print_global_defaults()` (the settings shown here are the
@@ -172,13 +172,11 @@ package default settings):
  'unicode_pm': False,
  'unc_pm_whitespace': True}
 
-The global default settings can be modified using
-:func:`set_global_defaults()` with the same keyword arguments passed
-into :class:`Formatter`.
-Any explicit options passed in will be updated while any unspecified
-options will retain their existing values.
-The same checks applied when constructing a :class:`Formatter` are
-applied to setting global default settings.
+The global default settings can be modified by passing
+:class:`FormatOptions` into :func:`set_global_defaults()`.
+Any options passed in the :class:`FormatOptions` will overwrite the
+current global default settings and any unfilled options will remain
+unchanged.
 
 >>> from sciform import (set_global_defaults, FillMode, ExpMode,
 ...                      GroupingSeparator)
@@ -220,7 +218,7 @@ using :func:`reset_global_defaults`.
 >>> from sciform import reset_global_defaults
 >>> reset_global_defaults()
 
-There are also helper function for managing supported
+There are also helper functions for managing supported
 :ref:`extra_translations`:
 
 * :func:`global_add_c_prefix()` add ``{-2: 'c'}`` to the
@@ -241,8 +239,7 @@ There are also helper function for managing supported
 
 The global default settings can be temporarily modified using the
 :class:`GlobalDefaultsContext` context manager.
-This context manager accepts the same keyword arguments as
-:class:`Formatter`.
+The context manager is also configured using :class:`FormatOptions`.
 Within the context of :class:`GlobalDefaultsContext` manager, the
 global defaults take on the specified input settings, but when the
 context is exited, the global default settings revert to their previous
@@ -256,20 +253,13 @@ values.
 ...     print(f'{snum:.2ep}')
 1.23 c
 
-:class:`SciNum` and :class:`SciNumUnc` objects load global settings when
-being *formatted*, not initialized.
-By contrast, :class:`Formatter` settings are configured and frozen when
-the class is initialized.
-Thus, changing global default settings with :func:`set_global_defaults`
-or with the :class:`GlobalDefaultsContext` will not change the behavior
-of any :class:`Formatter` that was instantiated before the change, but
-it will change :class:`SciNum` and :class:`SciNumUnc` formatting.
-Global configuration settings are, then, most useful for controlling the
-behavior of :class:`SciNum` and :class:`SciNumUnc` formatting.
-In particular, not all avaible options can be accessed using the
-:ref:`FSML <fsml>`, so the only way to modify these options while using
-:class:`SciNum` or :class:`SciNumUnc` formatting is via the global
-configuration settings.
+Note that the :ref:`FSML <fsml>` does not provide complete control over
+all possible format options.
+For example, there is no code in the :ref:`FSML <fsml>` for configuring
+the ``unicode_pm`` option.
+If the user wishes to configure these options but also use the
+:ref:`FSML <fsml>` then they must do so by modifying the global default
+settings.
 
 Note on Decimals and Floats
 ===========================

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -101,6 +101,8 @@ algorithm:
 #. The value and uncertainty mantissas are formatted together with the
    exponent according to the user-selected display options.
 
+.. _global_config:
+
 Global Configuration
 ====================
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -45,16 +45,17 @@ a corresponding formatted string.
 Note that global default options are used to populate unfilled options
 at formatting time.
 
+>>> from sciform import FormatOptions as Fo
 >>> from sciform import Formatter, RoundMode, GroupingSeparator, ExpMode
->>> sform = Formatter(round_mode=RoundMode.PREC,
-...                   precision=6,
-...                   upper_separator=GroupingSeparator.SPACE,
-...                   lower_separator=GroupingSeparator.SPACE)
+>>> sform = Formatter(Fo(round_mode=RoundMode.PREC,
+...                      precision=6,
+...                      upper_separator=GroupingSeparator.SPACE,
+...                      lower_separator=GroupingSeparator.SPACE))
 >>> print(sform(51413.14159265359))
 51 413.141 593
->>> sform = Formatter(round_mode=RoundMode.SIG_FIG,
-...                   precision=4,
-...                   exp_mode=ExpMode.ENGINEERING)
+>>> sform = Formatter(Fo(round_mode=RoundMode.SIG_FIG,
+...                      precision=4,
+...                      exp_mode=ExpMode.ENGINEERING))
 >>> print(sform(123456.78))
 123.5e+03
 
@@ -83,16 +84,16 @@ value/uncertainty strings.
 :mod:`sciform` attempts to follow
 `BIPM <https://www.bipm.org/documents/20126/2071204/JCGM_100_2008_E.pdf/cb0ef43f-baa5-11cf-3f85-4dcd86f77bd6>`_
 or `NIST <https://www.nist.gov/pml/nist-technical-note-1297>`_
-recomendations for conventions when possible.
+recommendations for conventions when possible.
 
-Value/uncertainty pairs can be formatted either by passing two values
+Value/uncertainty pairs can be formatted either by passing two numbers
 into a :class:`Formatter`, and configuring the :class:`Formatter` using
 :ref:`formatting_options` and :ref:`val_unc_formatting_options`, or by
 using the :class:`SciNumUnc` object.
 
 >>> val = 84.3
 >>> unc = 0.2
->>> sform = Formatter(precision=2)
+>>> sform = Formatter(Fo(precision=2))
 >>> print(sform(val, unc))
 84.30 +/- 0.20
 
@@ -114,7 +115,7 @@ algorithm:
 #. Rounding is always performed using significant figure rounding
    applied to the uncertainty. If a ``precision`` is supplied then the
    uncertainty is rounded to significant figures consistent with the
-   supplied ``precision``. Otherwise the uncertainty is left unrounded.
+   supplied ``precision``. Otherwise the uncertainty is left un-rounded.
 #. The value is rounded to the digit corresponding to the least
    significant digit of the rounded uncertainty.
 #. The value for the exponent is resolved by applying the
@@ -144,28 +145,28 @@ package default settings):
 
 >>> from sciform import print_global_defaults
 >>> print_global_defaults()
-{'fill_mode': <FillMode.SPACE: 'space'>,
- 'sign_mode': <SignMode.NEGATIVE: 'negative'>,
- 'top_dig_place': 0,
+{'exp_mode': <ExpMode.FIXEDPOINT: 'fixed_point'>,
+ 'exp': <class 'sciform.modes.AutoExp'>,
+ 'percent': False,
+ 'round_mode': <RoundMode.SIG_FIG: 'sig_fig'>,
+ 'precision': <class 'sciform.modes.AutoPrec'>,
  'upper_separator': <GroupingSeparator.NONE: 'no_grouping'>,
  'decimal_separator': <GroupingSeparator.POINT: 'point'>,
  'lower_separator': <GroupingSeparator.NONE: 'no_grouping'>,
- 'round_mode': <RoundMode.SIG_FIG: 'sig_fig'>,
- 'precision': <class 'sciform.modes.AutoPrec'>,
- 'exp_mode': <ExpMode.FIXEDPOINT: 'fixed_point'>,
- 'exp': <class 'sciform.modes.AutoExp'>,
- 'capitalize': False,
- 'percent': False,
- 'superscript_exp': False,
- 'latex': False,
- 'nan_inf_exp': False,
+ 'sign_mode': <SignMode.NEGATIVE: 'negative'>,
+ 'fill_mode': <FillMode.SPACE: 'space'>,
+ 'top_dig_place': 0,
  'prefix_exp': False,
  'parts_per_exp': False,
  'extra_si_prefixes': {},
  'extra_iec_prefixes': {},
  'extra_parts_per_forms': {},
- 'pdg_sig_figs': False,
+ 'capitalize': False,
+ 'superscript_exp': False,
+ 'latex': False,
+ 'nan_inf_exp': False,
  'bracket_unc': False,
+ 'pdg_sig_figs': False,
  'val_unc_match_widths': False,
  'bracket_unc_remove_seps': False,
  'unicode_pm': False,
@@ -181,33 +182,33 @@ applied to setting global default settings.
 
 >>> from sciform import (set_global_defaults, FillMode, ExpMode,
 ...                      GroupingSeparator)
->>> set_global_defaults(fill_mode=FillMode.ZERO,
-...                     exp_mode=ExpMode.ENGINEERING_SHIFTED,
-...                     precision=4,
-...                     decimal_separator=GroupingSeparator.COMMA)
+>>> set_global_defaults(Fo(fill_mode=FillMode.ZERO,
+...                        exp_mode=ExpMode.ENGINEERING_SHIFTED,
+...                        precision=4,
+...                        decimal_separator=GroupingSeparator.COMMA))
 >>> print_global_defaults()
-{'fill_mode': <FillMode.ZERO: 'zero'>,
- 'sign_mode': <SignMode.NEGATIVE: 'negative'>,
- 'top_dig_place': 0,
+{'exp_mode': <ExpMode.ENGINEERING_SHIFTED: 'engineering_shifted'>,
+ 'exp': <class 'sciform.modes.AutoExp'>,
+ 'percent': False,
+ 'round_mode': <RoundMode.SIG_FIG: 'sig_fig'>,
+ 'precision': 4,
  'upper_separator': <GroupingSeparator.NONE: 'no_grouping'>,
  'decimal_separator': <GroupingSeparator.COMMA: 'comma'>,
  'lower_separator': <GroupingSeparator.NONE: 'no_grouping'>,
- 'round_mode': <RoundMode.SIG_FIG: 'sig_fig'>,
- 'precision': 4,
- 'exp_mode': <ExpMode.ENGINEERING_SHIFTED: 'engineering_shifted'>,
- 'exp': <class 'sciform.modes.AutoExp'>,
- 'capitalize': False,
- 'percent': False,
- 'superscript_exp': False,
- 'latex': False,
- 'nan_inf_exp': False,
+ 'sign_mode': <SignMode.NEGATIVE: 'negative'>,
+ 'fill_mode': <FillMode.ZERO: 'zero'>,
+ 'top_dig_place': 0,
  'prefix_exp': False,
  'parts_per_exp': False,
  'extra_si_prefixes': {},
  'extra_iec_prefixes': {},
  'extra_parts_per_forms': {},
- 'pdg_sig_figs': False,
+ 'capitalize': False,
+ 'superscript_exp': False,
+ 'latex': False,
+ 'nan_inf_exp': False,
  'bracket_unc': False,
+ 'pdg_sig_figs': False,
  'val_unc_match_widths': False,
  'bracket_unc_remove_seps': False,
  'unicode_pm': False,
@@ -251,7 +252,7 @@ values.
 >>> snum = SciNum(0.0123)
 >>> print(f'{snum:.2ep}')
 1.23e-02
->>> with GlobalDefaultsContext(add_c_prefix=True):
+>>> with GlobalDefaultsContext(Fo(add_c_prefix=True)):
 ...     print(f'{snum:.2ep}')
 1.23 c
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -38,10 +38,12 @@ about how to view and modify the global default options.
 Formatter
 ---------
 
-The :class:`Formatter` object is initialized with user-selected
-formatting options and then used to format numbers.
-See :ref:`formatting_options` for more details about the available
-options.
+The :class:`Formatter` object is initialized and configured using a
+:class:`FormatOptions` object which contains the formatting settings.
+The :class:`FormatOptions` object is then called with number and returns
+a corresponding formatted string.
+Note that global default options are used to populate unfilled options
+at formatting time.
 
 >>> from sciform import Formatter, RoundMode, GroupingSeparator, ExpMode
 >>> sform = Formatter(round_mode=RoundMode.PREC,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sciform"
 authors = [
     {name = "Justin Gerber", email="justin.gerber48@gmail.com"}
 ]
-description = "A package for formatting floats into scientific formatted strings."
+description = "A package for formatting numbers into scientific formatted strings."
 classifiers = [
     "License :: OSI Approved :: MIT License"
 ]

--- a/src/sciform/__init__.py
+++ b/src/sciform/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "0.22.2"
 
+from sciform.format_options import FormatOptions
 from sciform.formatter import Formatter
 from sciform.scinum import SciNum, SciNumUnc
 from sciform.format_options import (
@@ -12,7 +13,7 @@ from sciform.format_options import (
 from sciform.modes import (FillMode, SignMode, GroupingSeparator, RoundMode,
                            ExpMode, AutoExp, AutoPrec)
 
-__all__ = ['__version__', 'Formatter', 'SciNum', 'SciNumUnc',
+__all__ = ['__version__', 'FormatOptions', 'Formatter', 'SciNum', 'SciNumUnc',
            'set_global_defaults', 'reset_global_defaults',
            'global_add_c_prefix', 'global_add_small_si_prefixes',
            'global_reset_si_prefixes', 'global_add_ppth_form',

--- a/src/sciform/__init__.py
+++ b/src/sciform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.22.2"
+__version__ = "0.23.0"
 
 from sciform.format_options import FormatOptions
 from sciform.formatter import Formatter

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -1,7 +1,5 @@
-from typing import Union, Optional, get_args
+from typing import Union, get_args
 from dataclasses import dataclass, asdict
-import re
-from copy import copy
 from pprint import pprint
 
 from sciform.modes import (FillMode, SignMode, GroupingSeparator,
@@ -11,184 +9,149 @@ from sciform.modes import (FillMode, SignMode, GroupingSeparator,
 
 
 @dataclass(frozen=True)
-class FormatOptions:
-    fill_mode: FillMode
-    sign_mode: SignMode
-    top_dig_place: int
+class RenderedFormatOptions:
+    exp_mode: ExpMode
+    exp: Union[int, type(AutoExp)]
+    percent: bool
+    round_mode: RoundMode
+    precision: Union[int, type(AutoPrec)]
     upper_separator: UpperGroupingSeparators
     decimal_separator: DecimalGroupingSeparators
     lower_separator: LowerGroupingSeparators
-    round_mode: RoundMode
-    precision: Union[int, type(AutoPrec)]
-    exp_mode: ExpMode
-    exp: Union[int, type(AutoExp)]
-    capitalize: bool
-    percent: bool
-    superscript_exp: bool
-    latex: bool
-    nan_inf_exp: bool
+    sign_mode: SignMode
+    fill_mode: FillMode
+    top_dig_place: int
     prefix_exp: bool
     parts_per_exp: bool
     extra_si_prefixes: dict[int, str]
     extra_iec_prefixes: dict[int, str]
     extra_parts_per_forms: dict[int, str]
-    pdg_sig_figs: bool
+    capitalize: bool
+    superscript_exp: bool
+    latex: bool
+    nan_inf_exp: bool
     bracket_unc: bool
+    pdg_sig_figs: bool
     val_unc_match_widths: bool
     bracket_unc_remove_seps: bool
     unicode_pm: bool
     unc_pm_whitespace: bool
 
-    def __post_init__(self):
-        if self.round_mode is RoundMode.SIG_FIG:
-            if isinstance(self.precision, int):
-                if self.precision < 1:
-                    raise ValueError(f'Precision must be >= 1 for sig fig '
-                                     f'rounding, not {self.precision}.')
 
-        if self.exp is not AutoExp:
-            if self.exp_mode is ExpMode.FIXEDPOINT:
-                if self.exp != 0:
-                    raise ValueError(f'Exponent must must be 0, not '
-                                     f'exp={self.exp}, for fixed point'
-                                     f'exponent mode.')
-            elif (self.exp_mode is ExpMode.ENGINEERING
-                  or self.exp_mode is ExpMode.ENGINEERING_SHIFTED):
-                if self.exp % 3 != 0:
-                    raise ValueError(f'Exponent must be a multiple of 3, not '
-                                     f'exp={self.exp}, for engineering '
-                                     f'exponent modes.')
-            elif self.exp_mode is ExpMode.BINARY_IEC:
-                if self.exp % 10 != 0:
-                    raise ValueError(f'Exponent must be a multiple of 10, not '
-                                     f'exp={self.exp}, for binary IEC '
-                                     f'exponent mode.')
+class Free:
+    """
+    Sentinel class indicating that a particular option in FormatOptions
+    is unpopulated. `Free` instances will be replaced with global
+    defaults upon rendering of FormatOptions into RenderedFormatOptions.
+    """
+    pass
 
-        if self.percent and self.exp_mode is not ExpMode.FIXEDPOINT:
-            raise ValueError('percent mode can only be used with fixed point '
-                             'exponent mode.')
 
-        if self.upper_separator not in get_args(UpperGroupingSeparators):
-            raise ValueError(f'upper_separator {self.upper_separator} not in '
-                             f'{get_args(UpperGroupingSeparators)}.')
+def is_free(obj) -> bool:
+    return isinstance(obj, Free)
 
-        if self.decimal_separator not in get_args(DecimalGroupingSeparators):
-            raise ValueError(f'decimal_separator {self.upper_separator} not '
-                             f'in {get_args(DecimalGroupingSeparators)}.')
 
-        if self.lower_separator not in get_args(LowerGroupingSeparators):
-            raise ValueError(f'lower_separator {self.lower_separator} not in '
-                             f'{get_args(LowerGroupingSeparators)}.')
+def is_not_free(obj) -> bool:
+    return not is_free(obj)
 
-        if self.upper_separator is self.decimal_separator:
-            raise ValueError(f'upper_separator and decimal_separator '
-                             f'{self.upper_separator} cannot be equal.')
 
-        if self.prefix_exp and self.parts_per_exp:
-            raise ValueError('Only one of prefix exponent and parts-per '
-                             'exponent modes may be selected.')
+ExpReplaceDict = dict[int, Union[str, None]]
 
-    @classmethod
-    def make(
-            cls,
+
+class FormatOptions:
+    def __init__(
+            self,
             *,
-            defaults: 'FormatOptions' = None,
-            fill_mode: FillMode = None,
-            sign_mode: SignMode = None,
-            top_dig_place: int = None,
-            upper_separator: UpperGroupingSeparators = None,
-            decimal_separator: DecimalGroupingSeparators = None,
-            lower_separator: LowerGroupingSeparators = None,
-            round_mode: RoundMode = None,
-            precision: Union[int, type(AutoPrec)] = None,
-            exp_mode: ExpMode = None,
-            exp: Union[int, type(AutoExp)] = None,
-            capitalize: bool = None,
-            percent: bool = None,
-            superscript_exp: bool = None,
-            latex: bool = None,
-            nan_inf_exp: bool = None,
-            prefix_exp: bool = None,
-            parts_per_exp: bool = None,
-            extra_si_prefixes: dict[int, str] = None,
-            extra_iec_prefixes: dict[int, str] = None,
-            extra_parts_per_forms: dict[int, str] = None,
+            template: Union['FormatOptions', RenderedFormatOptions] = None,
+            exp_mode: Union[ExpMode, Free] = Free(),
+            exp: Union[int, type(AutoExp), Free] = Free(),
+            percent: Union[bool, Free] = Free(),
+            round_mode: Union[RoundMode, Free] = Free(),
+            precision: Union[int, type(AutoPrec), Free] = Free(),
+            upper_separator: Union[UpperGroupingSeparators, Free] = Free(),
+            decimal_separator: Union[DecimalGroupingSeparators, Free] = Free(),
+            lower_separator: Union[LowerGroupingSeparators, Free] = Free(),
+            sign_mode: Union[SignMode, Free] = Free(),
+            fill_mode: Union[FillMode, Free] = Free(),
+            top_dig_place: Union[int, Free] = Free(),
+            prefix_exp: Union[bool, Free] = Free(),
+            parts_per_exp: Union[bool, Free] = Free(),
+            extra_si_prefixes: Union[ExpReplaceDict, Free] = Free(),
+            extra_iec_prefixes: Union[ExpReplaceDict, Free] = Free(),
+            extra_parts_per_forms: Union[ExpReplaceDict, Free] = Free(),
+            capitalize: Union[bool, Free] = Free(),
+            superscript_exp: Union[bool, Free] = Free(),
+            latex: Union[bool, Free] = Free(),
+            nan_inf_exp: Union[bool, Free] = Free(),
+            bracket_unc: Union[bool, Free] = Free(),
+            pdg_sig_figs: Union[bool, Free] = Free(),
+            val_unc_match_widths: Union[bool, Free] = Free(),
+            bracket_unc_remove_seps: Union[bool, Free] = Free(),
+            unicode_pm: Union[bool, Free] = Free(),
+            unc_pm_whitespace: Union[bool, Free] = Free(),
             add_c_prefix: bool = False,
             add_small_si_prefixes: bool = False,
-            add_ppth_form: bool = False,
-            pdg_sig_figs: bool = None,
-            bracket_unc: bool = None,
-            val_unc_match_widths: bool = None,
-            bracket_unc_remove_seps: bool = None,
-            unicode_pm: bool = None,
-            unc_pm_whitespace: bool = None
+            add_ppth_form: bool = False
     ):
-        if defaults is None:
-            defaults = DEFAULT_GLOBAL_OPTIONS
+        if round_mode is RoundMode.SIG_FIG:
+            if isinstance(precision, int):
+                if precision < 1:
+                    raise ValueError(f'Precision must be >= 1 for sig fig '
+                                     f'rounding, not {precision}.')
 
-        if fill_mode is None:
-            fill_mode = defaults.fill_mode
-        if sign_mode is None:
-            sign_mode = defaults.sign_mode
-        if top_dig_place is None:
-            top_dig_place = defaults.top_dig_place
-        if upper_separator is None:
-            upper_separator = defaults.upper_separator
-        if decimal_separator is None:
-            decimal_separator = defaults.decimal_separator
-        if lower_separator is None:
-            lower_separator = defaults.lower_separator
-        if round_mode is None:
-            round_mode = defaults.round_mode
-        if precision is None:
-            precision = defaults.precision
-        if exp_mode is None:
-            exp_mode = defaults.exp_mode
-        if exp is None:
-            exp = defaults.exp
-        if capitalize is None:
-            capitalize = defaults.capitalize
-        if percent is None:
-            percent = defaults.percent
-        if superscript_exp is None:
-            superscript_exp = defaults.superscript_exp
-        if latex is None:
-            latex = defaults.latex
-        if nan_inf_exp is None:
-            nan_inf_exp = defaults.nan_inf_exp
-        if prefix_exp is None:
-            prefix_exp = defaults.prefix_exp
-        if parts_per_exp is None:
-            parts_per_exp = defaults.parts_per_exp
-        if extra_si_prefixes is None:
-            extra_si_prefixes = copy(defaults.extra_si_prefixes)
-        else:
-            extra_si_prefixes = copy(extra_si_prefixes)
-        if extra_iec_prefixes is None:
-            extra_iec_prefixes = copy(defaults.extra_iec_prefixes)
-        else:
-            extra_iec_prefixes = copy(extra_iec_prefixes)
-        if extra_parts_per_forms is None:
-            extra_parts_per_forms = copy(defaults.extra_parts_per_forms)
-        else:
-            extra_parts_per_forms = copy(extra_parts_per_forms)
-        if pdg_sig_figs is None:
-            pdg_sig_figs = defaults.pdg_sig_figs
-        if bracket_unc is None:
-            bracket_unc = defaults.bracket_unc
-        if val_unc_match_widths is None:
-            val_unc_match_widths = defaults.val_unc_match_widths
-        if bracket_unc_remove_seps is None:
-            bracket_unc_remove_seps = defaults.bracket_unc_remove_seps
-        if unicode_pm is None:
-            unicode_pm = defaults.unicode_pm
-        if unc_pm_whitespace is None:
-            unc_pm_whitespace = defaults.unc_pm_whitespace
+        if not isinstance(exp, (AutoExp, Free)):
+            if exp_mode is ExpMode.FIXEDPOINT:
+                if exp != 0:
+                    raise ValueError(f'Exponent must must be 0, not '
+                                     f'exp={exp}, for fixed point exponent '
+                                     f'mode.')
+            elif (exp_mode is ExpMode.ENGINEERING
+                  or exp_mode is ExpMode.ENGINEERING_SHIFTED):
+                if exp % 3 != 0:
+                    raise ValueError(f'Exponent must be a multiple of 3, not '
+                                     f'exp={exp}, for engineering exponent '
+                                     f'modes.')
+            elif exp_mode is ExpMode.BINARY_IEC:
+                if exp % 10 != 0:
+                    raise ValueError(f'Exponent must be a multiple of 10, not '
+                                     f'exp={exp}, for binary IEC '
+                                     f'exponent mode.')
 
-        if add_c_prefix and -2 not in extra_si_prefixes:
-            extra_si_prefixes[-2] = 'c'
+        if not is_free(upper_separator):
+            if upper_separator not in get_args(UpperGroupingSeparators):
+                raise ValueError(f'upper_separator must be in '
+                                 f'{get_args(UpperGroupingSeparators)}, not '
+                                 f'{upper_separator}.')
+            if upper_separator is decimal_separator:
+                raise ValueError(f'upper_separator and decimal_separator '
+                                 f'({upper_separator}) cannot be equal.')
+
+        if not is_free(decimal_separator):
+            if decimal_separator not in get_args(DecimalGroupingSeparators):
+                raise ValueError(f'upper_separator must be in '
+                                 f'{get_args(DecimalGroupingSeparators)}, not '
+                                 f'{upper_separator}.')
+
+        if not is_free(lower_separator):
+            if lower_separator not in get_args(LowerGroupingSeparators):
+                raise ValueError(f'upper_separator must be in '
+                                 f'{get_args(LowerGroupingSeparators)}, not '
+                                 f'{upper_separator}.')
+
+        if not is_free(prefix_exp) and not is_free(parts_per_exp):
+            if prefix_exp and parts_per_exp:
+                raise ValueError('Only one of prefix exponent and parts-per '
+                                 'exponent modes may be selected.')
+
+        if add_c_prefix:
+            if is_free(extra_si_prefixes):
+                extra_si_prefixes = dict()
+            if -2 not in extra_si_prefixes:
+                extra_si_prefixes[-2] = 'c'
 
         if add_small_si_prefixes:
+            if is_free(extra_si_prefixes):
+                extra_si_prefixes = dict()
             if -2 not in extra_si_prefixes:
                 extra_si_prefixes[-2] = 'c'
             if -1 not in extra_si_prefixes:
@@ -199,210 +162,134 @@ class FormatOptions:
                 extra_si_prefixes[+2] = 'h'
 
         if add_ppth_form:
+            if is_free(extra_parts_per_forms):
+                extra_parts_per_forms = dict()
             if -3 not in extra_parts_per_forms:
                 extra_parts_per_forms[-3] = 'ppth'
 
-        return cls(
-            fill_mode=fill_mode,
-            sign_mode=sign_mode,
-            top_dig_place=top_dig_place,
-            upper_separator=upper_separator,
-            decimal_separator=decimal_separator,
-            lower_separator=lower_separator,
-            round_mode=round_mode,
-            precision=precision,
-            exp_mode=exp_mode,
-            exp=exp,
-            capitalize=capitalize,
-            percent=percent,
-            superscript_exp=superscript_exp,
-            latex=latex,
-            nan_inf_exp=nan_inf_exp,
-            prefix_exp=prefix_exp,
-            parts_per_exp=parts_per_exp,
-            extra_si_prefixes=extra_si_prefixes,
-            extra_iec_prefixes=extra_iec_prefixes,
-            extra_parts_per_forms=extra_parts_per_forms,
-            pdg_sig_figs=pdg_sig_figs,
-            bracket_unc=bracket_unc,
-            val_unc_match_widths=val_unc_match_widths,
-            bracket_unc_remove_seps=bracket_unc_remove_seps,
-            unicode_pm=unicode_pm,
-            unc_pm_whitespace=unc_pm_whitespace
-        )
-
-    pattern = re.compile(r'''^
-                             (?:(?P<fill_mode>[ 0])=)?
-                             (?P<sign_mode>[-+ ])?
-                             (?P<alternate_mode>\#)?
-                             (?P<top_dig_place>\d+)?
-                             (?P<upper_separator>[n,.s_])?
-                             (?P<decimal_separator>[.,])?
-                             (?P<lower_separator>[ns_])?
-                             (?:(?P<round_mode>[.!])(?P<prec>[+-]?\d+))?
-                             (?P<exp_mode>[fF%eErRbB])?
-                             (?:x(?P<exp>[+-]?\d+))?
-                             (?P<prefix_mode>p)?
-                             (?P<bracket_unc>\(\))?
-                             $''', re.VERBOSE)
-
-    fill_mode_mapping = {' ': FillMode.SPACE,
-                         '0': FillMode.ZERO,
-                         None: None}
-
-    sign_mode_mapping = {'-': SignMode.NEGATIVE,
-                         '+': SignMode.ALWAYS,
-                         ' ': SignMode.SPACE,
-                         None: None}
-
-    separator_mapping = {'n': GroupingSeparator.NONE,
-                         ',': GroupingSeparator.COMMA,
-                         '.': GroupingSeparator.POINT,
-                         's': GroupingSeparator.SPACE,
-                         '_': GroupingSeparator.UNDERSCORE,
-                         None: None}
-
-    round_mode_mapping = {'!': RoundMode.SIG_FIG,
-                          '.': RoundMode.PREC,
-                          None: None}
-
-    @classmethod
-    def from_format_spec_str(
-            cls,
-            fmt: str,
-            defaults: Optional['FormatOptions'] = None) -> 'FormatOptions':
-
-        match = cls.pattern.match(fmt)
-        if match is None:
-            raise ValueError(f'Invalid format specifier: \'{fmt}\'')
-
-        fill_mode_flag = match.group('fill_mode')
-        fill_mode = cls.fill_mode_mapping[fill_mode_flag]
-
-        sign_mode_flag = match.group('sign_mode')
-        sign_mode = cls.sign_mode_mapping[sign_mode_flag]
-
-        alternate_mode = match.group('alternate_mode')
-        if alternate_mode is not None:
-            alternate_mode = True
-
-        top_dig_place = match.group('top_dig_place')
-        if top_dig_place is not None:
-            top_dig_place = int(top_dig_place)
-            val_unc_match_widths = True
+        if template is None:
+            self.exp_mode = exp_mode
+            self.exp = exp
+            self.percent = percent
+            self.round_mode = round_mode
+            self.precision = precision
+            self.upper_separator = upper_separator
+            self.decimal_separator = decimal_separator
+            self.lower_separator = lower_separator
+            self.sign_mode = sign_mode
+            self.fill_mode = fill_mode
+            self.top_dig_place = top_dig_place
+            self.prefix_exp = prefix_exp
+            self.parts_per_exp = parts_per_exp
+            self.extra_si_prefixes = extra_si_prefixes
+            self.extra_iec_prefixes = extra_iec_prefixes
+            self.extra_parts_per_forms = extra_parts_per_forms
+            self.capitalize = capitalize
+            self.superscript_exp = superscript_exp
+            self.latex = latex
+            self.nan_inf_exp = nan_inf_exp
+            self.bracket_unc = bracket_unc
+            self.pdg_sig_figs = pdg_sig_figs
+            self.val_unc_match_widths = val_unc_match_widths
+            self.bracket_unc_remove_seps = bracket_unc_remove_seps
+            self.unicode_pm = unicode_pm
+            self.unc_pm_whitespace = unc_pm_whitespace
         else:
-            val_unc_match_widths = None
+            self.exp_mode = (template.exp_mode if is_free(exp_mode) else exp_mode)
+            self.exp = template.exp if is_free(exp) else exp
+            self.percent = template.percent if is_free(percent) else percent
+            self.round_mode = template.round_mode if is_free(round_mode) else round_mode
+            self.precision = template.precision if is_free(precision) else precision
+            self.upper_separator = template.upper_separator if is_free(upper_separator) else upper_separator
+            self.decimal_separator = template.decimal_separator if is_free(decimal_separator) else decimal_separator
+            self.lower_separator = template.lower_separator if is_free(lower_separator) else lower_separator
+            self.sign_mode = template.sign_mode if is_free(sign_mode) else sign_mode
+            self.fill_mode = template.fill_mode if is_free(fill_mode) else fill_mode
+            self.top_dig_place = template.top_dig_place if is_free(top_dig_place) else top_dig_place
+            self.prefix_exp = template.prefix_exp if is_free(prefix_exp) else prefix_exp
+            self.parts_per_exp = template.parts_per_exp if is_free(parts_per_exp) else parts_per_exp
+            self.extra_si_prefixes = template.extra_si_prefixes if is_free(extra_si_prefixes) else extra_si_prefixes
+            self.extra_iec_prefixes = template.extra_iec_prefixes if is_free(extra_iec_prefixes) else extra_iec_prefixes
+            self.extra_parts_per_forms = template.extra_parts_per_forms if is_free(extra_parts_per_forms) else extra_parts_per_forms
+            self.capitalize = template.capitalize if is_free(capitalize) else capitalize
+            self.superscript_exp = template.superscript_exp if is_free(superscript_exp) else superscript_exp
+            self.latex = template.latex if is_free(latex) else latex
+            self.nan_inf_exp = template.nan_inf_exp if is_free(nan_inf_exp) else nan_inf_exp
+            self.bracket_unc = template.bracket_unc if is_free(bracket_unc) else bracket_unc
+            self.pdg_sig_figs = template.pdg_sig_figs if is_free(pdg_sig_figs) else pdg_sig_figs
+            self.val_unc_match_widths = template.val_unc_match_widths if is_free(val_unc_match_widths) else val_unc_match_widths
+            self.bracket_unc_remove_seps = template.bracket_unc_remove_seps if is_free(bracket_unc_remove_seps) else bracket_unc_remove_seps
+            self.unicode_pm = template.unicode_pm if is_free(unicode_pm) else unicode_pm
+            self.unc_pm_whitespace = template.unc_pm_whitespace if is_free(unc_pm_whitespace) else unc_pm_whitespace
 
-        upper_separator_flag = match.group('upper_separator')
-        upper_separator = cls.separator_mapping[upper_separator_flag]
-
-        decimal_separator_flag = match.group('decimal_separator')
-        decimal_separator = cls.separator_mapping[decimal_separator_flag]
-
-        lower_separator_flag = match.group('lower_separator')
-        lower_separator = cls.separator_mapping[lower_separator_flag]
-
-        round_mode_flag = match.group('round_mode')
-        round_mode = cls.round_mode_mapping[round_mode_flag]
-
-        precision = match.group('prec')
-        if precision is not None:
-            precision = int(precision)
-
-        exp_mode = match.group('exp_mode')
-        percent = False
-        if exp_mode is not None:
-            capitalize = exp_mode.isupper()
-            if exp_mode in ['f', 'F']:
-                exp_mode = ExpMode.FIXEDPOINT
-            elif exp_mode == '%':
-                exp_mode = ExpMode.FIXEDPOINT
-                percent = True
-            elif exp_mode in ['e', 'E']:
-                exp_mode = ExpMode.SCIENTIFIC
-            elif exp_mode in ['r', 'R']:
-                if alternate_mode:
-                    exp_mode = ExpMode.ENGINEERING_SHIFTED
-                else:
-                    exp_mode = ExpMode.ENGINEERING
-            elif exp_mode in ['b', 'B']:
-                if alternate_mode:
-                    exp_mode = ExpMode.BINARY_IEC
-                else:
-                    exp_mode = ExpMode.BINARY
-        else:
-            capitalize = None
-
-        exp = match.group('exp')
-        if exp is not None:
-            exp = int(exp)
-
-        prefix_exp = match.group('prefix_mode')
-        if prefix_exp is not None:
-            prefix_exp = True
-
-        bracket_unc = match.group('bracket_unc')
-        if bracket_unc is not None:
-            bracket_unc = True
-
-        if defaults is None:
-            defaults = DEFAULT_GLOBAL_OPTIONS
-
-        return cls.make(
-            defaults=defaults,
-            fill_mode=fill_mode,
-            sign_mode=sign_mode,
-            top_dig_place=top_dig_place,
-            upper_separator=upper_separator,
-            decimal_separator=decimal_separator,
-            lower_separator=lower_separator,
-            round_mode=round_mode,
-            precision=precision,
-            exp_mode=exp_mode,
-            exp=exp,
-            capitalize=capitalize,
-            percent=percent,
-            prefix_exp=prefix_exp,
-            bracket_unc=bracket_unc,
-            val_unc_match_widths=val_unc_match_widths
+    def render(self) -> RenderedFormatOptions:
+        gdf = get_global_defaults()
+        rendered_format_options = RenderedFormatOptions(
+          exp_mode=gdf.exp_mode if is_free(self.exp_mode) else self.exp_mode,
+          exp=gdf.exp if is_free(self.exp) else self.exp,
+          percent=gdf.percent if is_free(self.percent) else self.percent,
+          round_mode=gdf.round_mode if is_free(self.round_mode) else self.round_mode,
+          precision=gdf.precision if is_free(self.precision) else self.precision,
+          upper_separator=gdf.upper_separator if is_free(self.upper_separator) else self.upper_separator,
+          decimal_separator=gdf.decimal_separator if is_free(self.decimal_separator) else self.decimal_separator,
+          lower_separator=gdf.lower_separator if is_free(self.lower_separator) else self.lower_separator,
+          sign_mode=gdf.sign_mode if is_free(self.sign_mode) else self.sign_mode,
+          fill_mode=gdf.fill_mode if is_free(self.fill_mode) else self.fill_mode,
+          top_dig_place=gdf.top_dig_place if is_free(self.top_dig_place) else self.top_dig_place,
+          prefix_exp=gdf.prefix_exp if is_free(self.prefix_exp) else self.prefix_exp,
+          parts_per_exp=gdf.parts_per_exp if is_free(self.parts_per_exp) else self.parts_per_exp,
+          extra_si_prefixes=gdf.extra_si_prefixes if is_free(self.extra_si_prefixes) else self.extra_si_prefixes,
+          extra_iec_prefixes=gdf.extra_iec_prefixes if is_free(self.extra_iec_prefixes) else self.extra_iec_prefixes,
+          extra_parts_per_forms=gdf.extra_parts_per_forms if is_free(self.extra_parts_per_forms) else self.extra_parts_per_forms,
+          capitalize=gdf.capitalize if is_free(self.capitalize) else self.capitalize,
+          superscript_exp=gdf.superscript_exp if is_free(self.superscript_exp) else self.superscript_exp,
+          latex=gdf.latex if is_free(self.latex) else self.latex,
+          nan_inf_exp=gdf.nan_inf_exp if is_free(self.nan_inf_exp) else self.nan_inf_exp,
+          bracket_unc=gdf.bracket_unc if is_free(self.bracket_unc) else self.bracket_unc,
+          pdg_sig_figs=gdf.pdg_sig_figs if is_free(self.pdg_sig_figs) else self.pdg_sig_figs,
+          val_unc_match_widths=gdf.val_unc_match_widths if is_free(self.val_unc_match_widths) else self.val_unc_match_widths,
+          bracket_unc_remove_seps=gdf.bracket_unc_remove_seps if is_free(self.bracket_unc_remove_seps) else self.bracket_unc_remove_seps,
+          unicode_pm=gdf.unicode_pm if is_free(self.unicode_pm) else self.unicode_pm,
+          unc_pm_whitespace=gdf.unc_pm_whitespace if is_free(self.unc_pm_whitespace) else self.unc_pm_whitespace
         )
+        return rendered_format_options
 
 
-DEFAULT_PKG_OPTIONS = FormatOptions(
-    fill_mode=FillMode.SPACE,
-    sign_mode=SignMode.NEGATIVE,
-    top_dig_place=0,
+DEFAULT_PKG_OPTIONS = RenderedFormatOptions(
+    exp_mode=ExpMode.FIXEDPOINT,
+    exp=AutoExp,
+    percent=False,
+    round_mode=RoundMode.SIG_FIG,
+    precision=AutoPrec,
     upper_separator=GroupingSeparator.NONE,
     decimal_separator=GroupingSeparator.POINT,
     lower_separator=GroupingSeparator.NONE,
-    round_mode=RoundMode.SIG_FIG,
-    precision=AutoPrec,
-    exp_mode=ExpMode.FIXEDPOINT,
-    exp=AutoExp,
-    capitalize=False,
-    percent=False,
-    superscript_exp=False,
-    latex=False,
-    nan_inf_exp=False,
+    sign_mode=SignMode.NEGATIVE,
+    fill_mode=FillMode.SPACE,
+    top_dig_place=0,
     prefix_exp=False,
     parts_per_exp=False,
     extra_si_prefixes=dict(),
     extra_iec_prefixes=dict(),
     extra_parts_per_forms=dict(),
-    pdg_sig_figs=False,
+    capitalize=False,
+    superscript_exp=False,
+    latex=False,
+    nan_inf_exp=False,
     bracket_unc=False,
+    pdg_sig_figs=False,
     val_unc_match_widths=False,
     bracket_unc_remove_seps=False,
     unicode_pm=False,
     unc_pm_whitespace=True
 )
 
-DEFAULT_GLOBAL_OPTIONS = FormatOptions.make(
-    defaults=DEFAULT_PKG_OPTIONS)
+
+GLOBAL_DEFAULT_OPTIONS = DEFAULT_PKG_OPTIONS
 
 
-def get_global_defaults() -> FormatOptions:
-    return DEFAULT_GLOBAL_OPTIONS
+def get_global_defaults() -> RenderedFormatOptions:
+    return GLOBAL_DEFAULT_OPTIONS
 
 
 def print_global_defaults():
@@ -412,89 +299,17 @@ def print_global_defaults():
     pprint(asdict(get_global_defaults()), sort_dicts=False)
 
 
-def set_global_defaults(
-        *,
-        defaults: 'FormatOptions' = None,  # TODO: This should not be user input
-        fill_mode: FillMode = None,
-        sign_mode: SignMode = None,
-        top_dig_place: int = None,
-        upper_separator: UpperGroupingSeparators = None,
-        decimal_separator: DecimalGroupingSeparators = None,
-        lower_separator: LowerGroupingSeparators = None,
-        round_mode: RoundMode = None,
-        precision: Union[int, type(AutoPrec)] = None,
-        exp_mode: ExpMode = None,
-        exp: Union[int, type(AutoExp)] = None,
-        capitalize: bool = None,
-        percent: bool = None,
-        superscript_exp: bool = None,
-        latex: bool = None,
-        nan_inf_exp=None,
-        prefix_exp: bool = None,
-        parts_per_exp: bool = None,
-        extra_si_prefixes: dict[int, str] = None,
-        extra_iec_prefixes: dict[int, str] = None,
-        extra_parts_per_forms: dict[int, str] = None,
-        add_c_prefix: bool = False,
-        add_small_si_prefixes: bool = False,
-        add_ppth_form: bool = False,
-        pdg_sig_figs: bool = None,
-        bracket_unc=None,
-        val_unc_match_widths=None,
-        bracket_unc_remove_seps=None,
-        unicode_pm=None,
-        unc_pm_whitespace=None
-):
-    """
-    Update global default options. Accepts the same input keyword
-    arguments as :class:`Formatter` and undergoes the same input
-    validation. Any unspecified parameters retain their existing
-    global settings.
-    """
-    global DEFAULT_GLOBAL_OPTIONS
-    if defaults is None:
-        defaults = DEFAULT_GLOBAL_OPTIONS
-    new_default_options = FormatOptions.make(
-        defaults=defaults,
-        fill_mode=fill_mode,
-        sign_mode=sign_mode,
-        top_dig_place=top_dig_place,
-        upper_separator=upper_separator,
-        decimal_separator=decimal_separator,
-        lower_separator=lower_separator,
-        round_mode=round_mode,
-        precision=precision,
-        exp_mode=exp_mode,
-        exp=exp,
-        capitalize=capitalize,
-        percent=percent,
-        superscript_exp=superscript_exp,
-        latex=latex,
-        nan_inf_exp=nan_inf_exp,
-        prefix_exp=prefix_exp,
-        parts_per_exp=parts_per_exp,
-        extra_si_prefixes=extra_si_prefixes,
-        extra_iec_prefixes=extra_iec_prefixes,
-        extra_parts_per_forms=extra_parts_per_forms,
-        add_c_prefix=add_c_prefix,
-        add_small_si_prefixes=add_small_si_prefixes,
-        add_ppth_form=add_ppth_form,
-        pdg_sig_figs=pdg_sig_figs,
-        bracket_unc=bracket_unc,
-        val_unc_match_widths=val_unc_match_widths,
-        bracket_unc_remove_seps=bracket_unc_remove_seps,
-        unicode_pm=unicode_pm,
-        unc_pm_whitespace=unc_pm_whitespace
-    )
-    DEFAULT_GLOBAL_OPTIONS = new_default_options
+def set_global_defaults(format_options: FormatOptions):
+    global GLOBAL_DEFAULT_OPTIONS
+    GLOBAL_DEFAULT_OPTIONS = format_options.render()
 
 
 def reset_global_defaults():
     """
     Reset global default options to package defaults.
     """
-    global DEFAULT_GLOBAL_OPTIONS
-    DEFAULT_GLOBAL_OPTIONS = DEFAULT_PKG_OPTIONS
+    global GLOBAL_DEFAULT_OPTIONS
+    GLOBAL_DEFAULT_OPTIONS = DEFAULT_PKG_OPTIONS
 
 
 def global_add_c_prefix():
@@ -504,7 +319,7 @@ def global_add_c_prefix():
     this mapping, first use :func:`global_reset_si_prefixes` or
     use :func:`set_global_defaults`.
     """
-    set_global_defaults(add_c_prefix=True)
+    set_global_defaults(FormatOptions(add_c_prefix=True))
 
 
 def global_add_small_si_prefixes():
@@ -515,7 +330,7 @@ def global_add_small_si_prefixes():
     mappings either first use :func:`global_reset_si_prefixes` or use
     :func:`set_global_defaults`.
     """
-    set_global_defaults(add_small_si_prefixes=True)
+    set_global_defaults(FormatOptions(add_small_si_prefixes=True))
 
 
 def global_add_ppth_form():
@@ -526,110 +341,45 @@ def global_add_ppth_form():
     :func:`global_reset_parts_per_forms` or use
     :func:`set_global_defaults`.
     """
-    set_global_defaults(add_ppth_form=True)
+    set_global_defaults(FormatOptions(add_ppth_form=True))
 
 
 def global_reset_si_prefixes():
     """
     Clear all extra SI prefix mappings.
     """
-    set_global_defaults(extra_si_prefixes=dict())
+    set_global_defaults(FormatOptions(extra_si_prefixes=dict()))
 
 
 def global_reset_iec_prefixes():
     """
     Clear all extra IEC prefix mappings.
     """
-    set_global_defaults(extra_iec_prefixes=dict())
+    set_global_defaults(FormatOptions(extra_iec_prefixes=dict()))
 
 
 def global_reset_parts_per_forms():
     """
     Clear all extra "parts-per" forms.
     """
-    set_global_defaults(extra_parts_per_forms=dict())
+    set_global_defaults(FormatOptions(extra_parts_per_forms=dict()))
 
 
 class GlobalDefaultsContext:
     """
-    Temporarily update global default options. Accepts the same input
-    keyword arguments as :class:`Formatter` and undergoes the same input
-    validation. Any unspecified parameters retain their existing
-    global settings. New settings are applied when the context is
-    entered and original global settings are re-applied when the context
-    is exited.
+    Temporarily update global default options. New settings are applied
+    when the context is entered and original global settings are
+    re-applied when the context is exited.
     """
-    def __init__(
-            self,
-            *,
-            defaults: 'FormatOptions' = None,
-            fill_mode: FillMode = None,
-            sign_mode: SignMode = None,
-            top_dig_place: int = None,
-            upper_separator: UpperGroupingSeparators = None,
-            decimal_separator: DecimalGroupingSeparators = None,
-            lower_separator: LowerGroupingSeparators = None,
-            round_mode: RoundMode = None,
-            precision: Union[int, type(AutoPrec)] = None,
-            exp_mode: ExpMode = None,
-            exp: Union[int, type(AutoExp)] = None,
-            capitalize: bool = None,
-            percent: bool = None,
-            superscript_exp: bool = None,
-            latex: bool = None,
-            nan_inf_exp: bool = None,
-            prefix_exp: bool = None,
-            parts_per_exp: bool = None,
-            extra_si_prefixes: dict[int, str] = None,
-            extra_iec_prefixes: dict[int, str] = None,
-            extra_parts_per_forms: dict[int, str] = None,
-            add_c_prefix: bool = False,
-            add_small_si_prefixes: bool = False,
-            add_ppth_form: bool = False,
-            pdg_sig_figs: bool = None,
-            bracket_unc: bool = None,
-            val_unc_match_widths: bool = None,
-            bracket_unc_remove_seps: bool = None,
-            unicode_pm: bool = None,
-            unc_pm_whitespace: bool = None
-    ):
-        self.options = FormatOptions.make(
-            defaults=defaults,
-            fill_mode=fill_mode,
-            sign_mode=sign_mode,
-            top_dig_place=top_dig_place,
-            upper_separator=upper_separator,
-            decimal_separator=decimal_separator,
-            lower_separator=lower_separator,
-            round_mode=round_mode,
-            precision=precision,
-            exp_mode=exp_mode,
-            exp=exp,
-            capitalize=capitalize,
-            percent=percent,
-            superscript_exp=superscript_exp,
-            latex=latex,
-            nan_inf_exp=nan_inf_exp,
-            prefix_exp=prefix_exp,
-            parts_per_exp=parts_per_exp,
-            extra_si_prefixes=extra_si_prefixes,
-            extra_iec_prefixes=extra_iec_prefixes,
-            extra_parts_per_forms=extra_parts_per_forms,
-            add_c_prefix=add_c_prefix,
-            add_small_si_prefixes=add_small_si_prefixes,
-            add_ppth_form=add_ppth_form,
-            pdg_sig_figs=pdg_sig_figs,
-            bracket_unc=bracket_unc,
-            val_unc_match_widths=val_unc_match_widths,
-            bracket_unc_remove_seps=bracket_unc_remove_seps,
-            unicode_pm=unicode_pm,
-            unc_pm_whitespace=unc_pm_whitespace
-        )
+    def __init__(self, format_options: FormatOptions):
+        self.format_options = format_options
         self.initial_global_defaults = None
 
     def __enter__(self):
-        self.initial_global_defaults = get_global_defaults()
-        set_global_defaults(defaults=self.options)
+        global GLOBAL_DEFAULT_OPTIONS
+        self.initial_global_defaults = GLOBAL_DEFAULT_OPTIONS
+        GLOBAL_DEFAULT_OPTIONS = self.format_options.render()
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        set_global_defaults(defaults=self.initial_global_defaults)
+        global GLOBAL_DEFAULT_OPTIONS
+        GLOBAL_DEFAULT_OPTIONS = self.initial_global_defaults

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -38,23 +38,6 @@ class RenderedFormatOptions:
     unc_pm_whitespace: bool
 
 
-class Free:
-    """
-    Sentinel class indicating that a particular option in FormatOptions
-    is unpopulated. `Free` instances will be replaced with global
-    defaults upon rendering of FormatOptions into RenderedFormatOptions.
-    """
-    pass
-
-
-def is_free(obj) -> bool:
-    return isinstance(obj, Free)
-
-
-def is_not_free(obj) -> bool:
-    return not is_free(obj)
-
-
 ExpReplaceDict = dict[int, Union[str, None]]
 
 
@@ -63,32 +46,32 @@ class FormatOptions:
             self,
             *,
             template: Union['FormatOptions'] = None,
-            exp_mode: Union[ExpMode, Free] = Free(),
-            exp: Union[int, type(AutoExp), Free] = Free(),
-            percent: Union[bool, Free] = Free(),
-            round_mode: Union[RoundMode, Free] = Free(),
-            precision: Union[int, type(AutoPrec), Free] = Free(),
-            upper_separator: Union[UpperGroupingSeparators, Free] = Free(),
-            decimal_separator: Union[DecimalGroupingSeparators, Free] = Free(),
-            lower_separator: Union[LowerGroupingSeparators, Free] = Free(),
-            sign_mode: Union[SignMode, Free] = Free(),
-            fill_mode: Union[FillMode, Free] = Free(),
-            top_dig_place: Union[int, Free] = Free(),
-            prefix_exp: Union[bool, Free] = Free(),
-            parts_per_exp: Union[bool, Free] = Free(),
-            extra_si_prefixes: Union[ExpReplaceDict, Free] = Free(),
-            extra_iec_prefixes: Union[ExpReplaceDict, Free] = Free(),
-            extra_parts_per_forms: Union[ExpReplaceDict, Free] = Free(),
-            capitalize: Union[bool, Free] = Free(),
-            superscript_exp: Union[bool, Free] = Free(),
-            latex: Union[bool, Free] = Free(),
-            nan_inf_exp: Union[bool, Free] = Free(),
-            bracket_unc: Union[bool, Free] = Free(),
-            pdg_sig_figs: Union[bool, Free] = Free(),
-            val_unc_match_widths: Union[bool, Free] = Free(),
-            bracket_unc_remove_seps: Union[bool, Free] = Free(),
-            unicode_pm: Union[bool, Free] = Free(),
-            unc_pm_whitespace: Union[bool, Free] = Free(),
+            exp_mode: ExpMode = None,
+            exp: Union[int, type(AutoExp)] = None,
+            percent: bool = None,
+            round_mode: RoundMode = None,
+            precision: Union[int, type(AutoPrec)] = None,
+            upper_separator: UpperGroupingSeparators = None,
+            decimal_separator: DecimalGroupingSeparators = None,
+            lower_separator: LowerGroupingSeparators = None,
+            sign_mode: SignMode = None,
+            fill_mode: FillMode = None,
+            top_dig_place: int = None,
+            prefix_exp: bool = None,
+            parts_per_exp: bool = None,
+            extra_si_prefixes: ExpReplaceDict = None,
+            extra_iec_prefixes: ExpReplaceDict = None,
+            extra_parts_per_forms: ExpReplaceDict = None,
+            capitalize: bool = None,
+            superscript_exp: bool = None,
+            latex: bool = None,
+            nan_inf_exp: bool = None,
+            bracket_unc: bool = None,
+            pdg_sig_figs: bool = None,
+            val_unc_match_widths: bool = None,
+            bracket_unc_remove_seps: bool = None,
+            unicode_pm: bool = None,
+            unc_pm_whitespace: bool = None,
             add_c_prefix: bool = False,
             add_small_si_prefixes: bool = False,
             add_ppth_form: bool = False
@@ -99,7 +82,7 @@ class FormatOptions:
                     raise ValueError(f'Precision must be >= 1 for sig fig '
                                      f'rounding, not {precision}.')
 
-        if exp is not AutoExp and not isinstance(exp, Free):
+        if exp is not AutoExp and exp is not None:
             if exp_mode is ExpMode.FIXEDPOINT:
                 if exp != 0:
                     raise ValueError(f'Exponent must must be 0, not '
@@ -117,7 +100,7 @@ class FormatOptions:
                                      f'exp={exp}, for binary IEC '
                                      f'exponent mode.')
 
-        if not is_free(upper_separator):
+        if upper_separator is not None:
             if upper_separator not in get_args(UpperGroupingSeparators):
                 raise ValueError(f'upper_separator must be in '
                                  f'{get_args(UpperGroupingSeparators)}, not '
@@ -126,31 +109,31 @@ class FormatOptions:
                 raise ValueError(f'upper_separator and decimal_separator '
                                  f'({upper_separator}) cannot be equal.')
 
-        if not is_free(decimal_separator):
+        if decimal_separator is not None:
             if decimal_separator not in get_args(DecimalGroupingSeparators):
                 raise ValueError(f'upper_separator must be in '
                                  f'{get_args(DecimalGroupingSeparators)}, not '
                                  f'{upper_separator}.')
 
-        if not is_free(lower_separator):
+        if lower_separator is not None:
             if lower_separator not in get_args(LowerGroupingSeparators):
                 raise ValueError(f'upper_separator must be in '
                                  f'{get_args(LowerGroupingSeparators)}, not '
                                  f'{upper_separator}.')
 
-        if not is_free(prefix_exp) and not is_free(parts_per_exp):
+        if prefix_exp is not None and parts_per_exp is not None:
             if prefix_exp and parts_per_exp:
                 raise ValueError('Only one of prefix exponent and parts-per '
                                  'exponent modes may be selected.')
 
         if add_c_prefix:
-            if is_free(extra_si_prefixes):
+            if extra_si_prefixes is None:
                 extra_si_prefixes = dict()
             if -2 not in extra_si_prefixes:
                 extra_si_prefixes[-2] = 'c'
 
         if add_small_si_prefixes:
-            if is_free(extra_si_prefixes):
+            if extra_si_prefixes is None:
                 extra_si_prefixes = dict()
             if -2 not in extra_si_prefixes:
                 extra_si_prefixes[-2] = 'c'
@@ -162,7 +145,7 @@ class FormatOptions:
                 extra_si_prefixes[+2] = 'h'
 
         if add_ppth_form:
-            if is_free(extra_parts_per_forms):
+            if extra_parts_per_forms is None:
                 extra_parts_per_forms = dict()
             if -3 not in extra_parts_per_forms:
                 extra_parts_per_forms[-3] = 'ppth'
@@ -195,62 +178,62 @@ class FormatOptions:
             self.unicode_pm = unicode_pm
             self.unc_pm_whitespace = unc_pm_whitespace
         else:
-            self.exp_mode = (template.exp_mode if is_free(exp_mode) else exp_mode)
-            self.exp = template.exp if is_free(exp) else exp
-            self.percent = template.percent if is_free(percent) else percent
-            self.round_mode = template.round_mode if is_free(round_mode) else round_mode
-            self.precision = template.precision if is_free(precision) else precision
-            self.upper_separator = template.upper_separator if is_free(upper_separator) else upper_separator
-            self.decimal_separator = template.decimal_separator if is_free(decimal_separator) else decimal_separator
-            self.lower_separator = template.lower_separator if is_free(lower_separator) else lower_separator
-            self.sign_mode = template.sign_mode if is_free(sign_mode) else sign_mode
-            self.fill_mode = template.fill_mode if is_free(fill_mode) else fill_mode
-            self.top_dig_place = template.top_dig_place if is_free(top_dig_place) else top_dig_place
-            self.prefix_exp = template.prefix_exp if is_free(prefix_exp) else prefix_exp
-            self.parts_per_exp = template.parts_per_exp if is_free(parts_per_exp) else parts_per_exp
-            self.extra_si_prefixes = template.extra_si_prefixes if is_free(extra_si_prefixes) else extra_si_prefixes
-            self.extra_iec_prefixes = template.extra_iec_prefixes if is_free(extra_iec_prefixes) else extra_iec_prefixes
-            self.extra_parts_per_forms = template.extra_parts_per_forms if is_free(extra_parts_per_forms) else extra_parts_per_forms
-            self.capitalize = template.capitalize if is_free(capitalize) else capitalize
-            self.superscript_exp = template.superscript_exp if is_free(superscript_exp) else superscript_exp
-            self.latex = template.latex if is_free(latex) else latex
-            self.nan_inf_exp = template.nan_inf_exp if is_free(nan_inf_exp) else nan_inf_exp
-            self.bracket_unc = template.bracket_unc if is_free(bracket_unc) else bracket_unc
-            self.pdg_sig_figs = template.pdg_sig_figs if is_free(pdg_sig_figs) else pdg_sig_figs
-            self.val_unc_match_widths = template.val_unc_match_widths if is_free(val_unc_match_widths) else val_unc_match_widths
-            self.bracket_unc_remove_seps = template.bracket_unc_remove_seps if is_free(bracket_unc_remove_seps) else bracket_unc_remove_seps
-            self.unicode_pm = template.unicode_pm if is_free(unicode_pm) else unicode_pm
-            self.unc_pm_whitespace = template.unc_pm_whitespace if is_free(unc_pm_whitespace) else unc_pm_whitespace
+            self.exp_mode = (template.exp_mode if exp_mode is None else exp_mode)
+            self.exp = template.exp if exp is None else exp
+            self.percent = template.percent if percent is None else percent
+            self.round_mode = template.round_mode if round_mode is None else round_mode
+            self.precision = template.precision if precision is None else precision
+            self.upper_separator = template.upper_separator if upper_separator is None else upper_separator
+            self.decimal_separator = template.decimal_separator if decimal_separator is None else decimal_separator
+            self.lower_separator = template.lower_separator if lower_separator is None else lower_separator
+            self.sign_mode = template.sign_mode if sign_mode is None else sign_mode
+            self.fill_mode = template.fill_mode if fill_mode is None else fill_mode
+            self.top_dig_place = template.top_dig_place if top_dig_place is None else top_dig_place
+            self.prefix_exp = template.prefix_exp if prefix_exp is None else prefix_exp
+            self.parts_per_exp = template.parts_per_exp if parts_per_exp is None else parts_per_exp
+            self.extra_si_prefixes = template.extra_si_prefixes if extra_si_prefixes is None else extra_si_prefixes
+            self.extra_iec_prefixes = template.extra_iec_prefixes if extra_iec_prefixes is None else extra_iec_prefixes
+            self.extra_parts_per_forms = template.extra_parts_per_forms if extra_parts_per_forms is None else extra_parts_per_forms
+            self.capitalize = template.capitalize if capitalize is None else capitalize
+            self.superscript_exp = template.superscript_exp if superscript_exp is None else superscript_exp
+            self.latex = template.latex if latex is None else latex
+            self.nan_inf_exp = template.nan_inf_exp if nan_inf_exp is None else nan_inf_exp
+            self.bracket_unc = template.bracket_unc if bracket_unc is None else bracket_unc
+            self.pdg_sig_figs = template.pdg_sig_figs if pdg_sig_figs is None else pdg_sig_figs
+            self.val_unc_match_widths = template.val_unc_match_widths if val_unc_match_widths is None else val_unc_match_widths
+            self.bracket_unc_remove_seps = template.bracket_unc_remove_seps if bracket_unc_remove_seps is None else bracket_unc_remove_seps
+            self.unicode_pm = template.unicode_pm if unicode_pm is None else unicode_pm
+            self.unc_pm_whitespace = template.unc_pm_whitespace if unc_pm_whitespace is None else unc_pm_whitespace
 
     def render(self) -> RenderedFormatOptions:
         gdf = get_global_defaults()
         rendered_format_options = RenderedFormatOptions(
-          exp_mode=gdf.exp_mode if is_free(self.exp_mode) else self.exp_mode,
-          exp=gdf.exp if is_free(self.exp) else self.exp,
-          percent=gdf.percent if is_free(self.percent) else self.percent,
-          round_mode=gdf.round_mode if is_free(self.round_mode) else self.round_mode,
-          precision=gdf.precision if is_free(self.precision) else self.precision,
-          upper_separator=gdf.upper_separator if is_free(self.upper_separator) else self.upper_separator,
-          decimal_separator=gdf.decimal_separator if is_free(self.decimal_separator) else self.decimal_separator,
-          lower_separator=gdf.lower_separator if is_free(self.lower_separator) else self.lower_separator,
-          sign_mode=gdf.sign_mode if is_free(self.sign_mode) else self.sign_mode,
-          fill_mode=gdf.fill_mode if is_free(self.fill_mode) else self.fill_mode,
-          top_dig_place=gdf.top_dig_place if is_free(self.top_dig_place) else self.top_dig_place,
-          prefix_exp=gdf.prefix_exp if is_free(self.prefix_exp) else self.prefix_exp,
-          parts_per_exp=gdf.parts_per_exp if is_free(self.parts_per_exp) else self.parts_per_exp,
-          extra_si_prefixes=gdf.extra_si_prefixes if is_free(self.extra_si_prefixes) else self.extra_si_prefixes,
-          extra_iec_prefixes=gdf.extra_iec_prefixes if is_free(self.extra_iec_prefixes) else self.extra_iec_prefixes,
-          extra_parts_per_forms=gdf.extra_parts_per_forms if is_free(self.extra_parts_per_forms) else self.extra_parts_per_forms,
-          capitalize=gdf.capitalize if is_free(self.capitalize) else self.capitalize,
-          superscript_exp=gdf.superscript_exp if is_free(self.superscript_exp) else self.superscript_exp,
-          latex=gdf.latex if is_free(self.latex) else self.latex,
-          nan_inf_exp=gdf.nan_inf_exp if is_free(self.nan_inf_exp) else self.nan_inf_exp,
-          bracket_unc=gdf.bracket_unc if is_free(self.bracket_unc) else self.bracket_unc,
-          pdg_sig_figs=gdf.pdg_sig_figs if is_free(self.pdg_sig_figs) else self.pdg_sig_figs,
-          val_unc_match_widths=gdf.val_unc_match_widths if is_free(self.val_unc_match_widths) else self.val_unc_match_widths,
-          bracket_unc_remove_seps=gdf.bracket_unc_remove_seps if is_free(self.bracket_unc_remove_seps) else self.bracket_unc_remove_seps,
-          unicode_pm=gdf.unicode_pm if is_free(self.unicode_pm) else self.unicode_pm,
-          unc_pm_whitespace=gdf.unc_pm_whitespace if is_free(self.unc_pm_whitespace) else self.unc_pm_whitespace
+          exp_mode=gdf.exp_mode if self.exp_mode is None else self.exp_mode,
+          exp=gdf.exp if self.exp is None else self.exp,
+          percent=gdf.percent if self.percent is None else self.percent,
+          round_mode=gdf.round_mode if self.round_mode is None else self.round_mode,
+          precision=gdf.precision if self.precision is None else self.precision,
+          upper_separator=gdf.upper_separator if self.upper_separator is None else self.upper_separator,
+          decimal_separator=gdf.decimal_separator if self.decimal_separator is None else self.decimal_separator,
+          lower_separator=gdf.lower_separator if self.lower_separator is None else self.lower_separator,
+          sign_mode=gdf.sign_mode if self.sign_mode is None else self.sign_mode,
+          fill_mode=gdf.fill_mode if self.fill_mode is None else self.fill_mode,
+          top_dig_place=gdf.top_dig_place if self.top_dig_place is None else self.top_dig_place,
+          prefix_exp=gdf.prefix_exp if self.prefix_exp is None else self.prefix_exp,
+          parts_per_exp=gdf.parts_per_exp if self.parts_per_exp is None else self.parts_per_exp,
+          extra_si_prefixes=gdf.extra_si_prefixes if self.extra_si_prefixes is None else self.extra_si_prefixes,
+          extra_iec_prefixes=gdf.extra_iec_prefixes if self.extra_iec_prefixes is None else self.extra_iec_prefixes,
+          extra_parts_per_forms=gdf.extra_parts_per_forms if self.extra_parts_per_forms is None else self.extra_parts_per_forms,
+          capitalize=gdf.capitalize if self.capitalize is None else self.capitalize,
+          superscript_exp=gdf.superscript_exp if self.superscript_exp is None else self.superscript_exp,
+          latex=gdf.latex if self.latex is None else self.latex,
+          nan_inf_exp=gdf.nan_inf_exp if self.nan_inf_exp is None else self.nan_inf_exp,
+          bracket_unc=gdf.bracket_unc if self.bracket_unc is None else self.bracket_unc,
+          pdg_sig_figs=gdf.pdg_sig_figs if self.pdg_sig_figs is None else self.pdg_sig_figs,
+          val_unc_match_widths=gdf.val_unc_match_widths if self.val_unc_match_widths is None else self.val_unc_match_widths,
+          bracket_unc_remove_seps=gdf.bracket_unc_remove_seps if self.bracket_unc_remove_seps is None else self.bracket_unc_remove_seps,
+          unicode_pm=gdf.unicode_pm if self.unicode_pm is None else self.unicode_pm,
+          unc_pm_whitespace=gdf.unc_pm_whitespace if self.unc_pm_whitespace is None else self.unc_pm_whitespace
         )
         return rendered_format_options
 

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -51,10 +51,10 @@ class FormatOptions:
     instances and to modify the global default configuration.
 
     It is not necessary to provide input for all options. There are two
-    mechanisms for filling of any unsupplied options. First, the user
-    can pass in another :class:`FormatOptions` instance as a
-    ``template``. In this case any populated options for the
-    ``template`` will be used to populate corresponding unpopulated
+    mechanisms for filling of any un-supplied options. First, during
+    initialization, the user can pass in another :class:`FormatOptions`
+    instance as a ``template``. In this case any populated options for
+    the ``template`` will be used to populate corresponding unpopulated
     options for the new :class:`FormatOptions`. Second, at format time
     any remaining unfilled options will be populated with the global
     default options. See :ref:`global_config` for details about how to

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -99,7 +99,7 @@ class FormatOptions:
                     raise ValueError(f'Precision must be >= 1 for sig fig '
                                      f'rounding, not {precision}.')
 
-        if not isinstance(exp, (AutoExp, Free)):
+        if exp is not AutoExp and not isinstance(exp, Free):
             if exp_mode is ExpMode.FIXEDPOINT:
                 if exp != 0:
                     raise ValueError(f'Exponent must must be 0, not '

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -62,7 +62,7 @@ class FormatOptions:
     def __init__(
             self,
             *,
-            template: Union['FormatOptions', RenderedFormatOptions] = None,
+            template: Union['FormatOptions'] = None,
             exp_mode: Union[ExpMode, Free] = Free(),
             exp: Union[int, type(AutoExp), Free] = Free(),
             percent: Union[bool, Free] = Free(),

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -42,6 +42,139 @@ ExpReplaceDict = dict[int, Union[str, None]]
 
 
 class FormatOptions:
+    """
+    :class:`FormatOptions` stores all the configuration options used to
+    format numbers and number/uncertainty pairs. See
+    :ref:`formatting_options` for more details on the available options.
+    :class:`FormatOptions` are used to create :class:`Formatter`
+    instances and to modify the global default configuration.
+
+    It is not necessary to provide input for all options. There are two
+    mechanisms for filling of any unsupplied options. First, the user
+    can pass in another :class:`FormatOptions` instance as a
+    ``template``. In this case any populated options for the
+    ``template`` will be used to populate corresponding unpopulated
+    options for the new :class:`FormatOptions`. Second, at format time
+    any remaining unfilled options will be populated with the global
+    default options. See :ref:`global_config` for details about how to
+    view and modify the global default options.
+
+    The following checks are performed when creating a new
+    :class:`FormatOptions` object:
+
+    * ``precision`` >= 1 for significant figure rounding mode
+    * ``exp`` must be consistent with the exponent mode:
+
+      * ``exp`` must be 0 for fixed point and percent modes
+      * ``exp`` must be a multiple of 3 for engineering and shifted
+        engineering modes
+      * ``exp`` must be a multiple of 10 for binary iec mode
+
+    * ``upper_separator`` may be any :class:`GroupingSeparator` but must
+      be different from ``decimal_separator``
+    * ``decimal_separator`` may only be :class:`GroupingSeparator.POINT`
+      or :class:`GroupingSeparator.COMMA`
+    * ``lower_separator`` may only be :class:`GroupingSeparator.NONE`,
+      :class:`GroupingSeparator.SPACE`, or
+      :class:`GroupingSeparator.UNDERSCORE`
+    * Only one of ``prefix_exp`` and ``parts_per_exp`` may be selected.
+
+    :param template: :class:`FormatOptions` instance to use to populate
+      unfilled options.
+    :param exp_mode: :class:`ExpMode` indicating the formatting
+      mode to be used.
+    :param exp: :class:`int` or :class:`AutoExp` indicating the value which
+      should be used for the exponent. This parameter is ignored for the
+      fixed point exponent mode. For engineering, engineering shifted,
+      and binary iec modes, if this parameter is not consistent with the
+      rules of that mode (e.g. if it is not a multiple of 3), then the
+      exponent is rounded down to the nearest conforming value and a
+      warning is printed.
+    :param percent: :class:`bool` indicating whether the number should be
+      formatted as a percentage or not. Only valid for fixed point
+      exponent mode. When ``True``, the number is multipled by 100 and
+      a ``%`` symbol is appended to the end of the string after
+      formatting.
+    :param round_mode: :class:`RoundMode` indicating whether to round
+      the number based on significant figures or digits past the
+      decimal point
+    :param precision: :class:`int` or :class:`AutoPrec` sentinel indicating
+      how many significant figures or digits past the decimal point to
+      include for rounding. Must be >= 1 for significant figure
+      rounding. May be any integer for digits-past-the-decimal rounding.
+    :param upper_separator: :class:`GroupingSeparator` indicating the
+      character to be used to group digits above the decimal symbol.
+    :param decimal_separator: :class:`GroupingSeparator` indicating
+      the character to be used as the decimal symbol.
+      :class:`GroupingSeparator.POINT` or
+      :class:`GroupingSeparator.COMMA`. Note that ``decimal_separator``
+      cannot be the same as ``upper_separator``
+    :param lower_separator: :class:`GroupingSeparator` indicating the
+      character to be used to group digits below the decimal symbol.
+      :class:`GroupingSeparator.NONE`, :class:`GroupingSeparator.SPACE`,
+      or :class:`GroupingSeparator.UNDERSCORE`.
+    :param sign_mode: :class:`SignMode` indicating sign
+      symbol behavior.
+    :param fill_mode: :class:`FillMode` indicating whether
+      to fill with zeros or spaces.
+    :param top_dig_place: Positive ``int`` indicating the digits place
+      to which the string will be left padded before the sign symbol. 0
+      corresponds to the ones place, 1 corresponds to the tens place
+      etc. E.g. ``top_dig_place=4`` will convert ``12`` into ``00012``.
+    :param prefix_exp: :class:`bool` indicating if exponents should be
+      replaced with either SI or IEC prefixes as appropriate.
+    :param parts_per_exp: :class:`bool` indicating if "parts-per" exponent
+      translations should be used.
+    :param extra_si_prefixes: ``dict[int, Union[str, None]]`` mapping
+      additional exponent values to si prefixes. Entries overwrite
+      default values. A value of ``None`` means that exponent will not
+      be converted.
+    :param extra_iec_prefixes: ``dict[int, Union[str, None]]`` mapping
+      additional exponent values to iec prefixes. Entries overwrite
+      default values. A value of ``None`` means that exponent will not
+      be converted.
+    :param extra_parts_per_forms: ``dict[int, Union[str, None]]``
+      mapping additional exponent values to "parts-per" forms. Entries
+      overwrite default values. A value of ``None`` means that exponent
+      will not be converted.
+    :param capitalize: :class:`bool` indicating whether the exponentiation
+      symbol should be upper- or lower-case.
+    :param superscript_exp: :class:`bool` indicating if the exponent string
+      should be converted into superscript notation. E.g. ``'1.23e+02'``
+      is converted to ``'1.23×10²'``
+    :param latex: :class:`bool` indicating if the resulting string should be
+      converted into a latex parseable code, e.g.
+      ``'\\left(1.23 \\pm 0.01\\right)\\times 10^{2}'``.
+    :param nan_inf_exp: :class:`bool` indicating whether non-finite numbers
+      such as ``float('nan')`` or ``float('inf')`` should be formatted
+      with exponent symbols when exponent modes including exponent
+      symbols are selected.
+    :param bracket_unc: :class:`bool` indicating if bracket uncertainty mode
+      (e.g. ``12.34(82)`` instead of ``12.34 +/- 0.82``) should be used.
+    :param pdg_sig_figs: :class:`bool` indicating whether the
+      particle-data-group conventions should be used to automatically
+      determine the number of significant figures to use for
+      uncertainty.
+    :param val_unc_match_widths: :class:`bool` indicating if the value or
+      uncertainty should be left padded to ensure they are both left
+      padded to the same digits place.
+    :param bracket_unc_remove_seps: :class:`bool` indicating if separator
+      symbols should be removed from the uncertainty when using bracket
+      uncertainty mode. E.g. expressing ``123.4 +/- 2.3`` as
+      ``123.4(23)`` instead of ``123.4(2.3)``.
+    :param unicode_pm: :class:`bool` indicating if the '+/-' separator should
+      be replaced with the unicode plus minus symbol '±'.
+    :param unc_pm_whitespace: :class:`bool` indicating if there should be
+      whitespace surrounding the ``'+/-'`` symbols when formatting. E.g.
+      ``123.4+/-2.3`` compared to ``123.4 +/- 2.3``.
+    :param add_c_prefix: :class:`bool` (default ``False``) if ``True`` adds
+      ``{-2: 'c'}`` to ``extra_si_prefixes``.
+    :param add_small_si_prefixes: ``bool`` (default ``False``) if
+      ``True`` adds ``{-2: 'c', -1: 'd', +1: 'da', +2: 'h'}`` to
+      ``extra_si_prefixes``.
+    :param add_ppth_form: :class:`bool` (default ``False``) if ``True`` adds
+      ``{-3: 'ppth'}`` to ``extra_parts_per_forms``.
+    """
     def __init__(
             self,
             *,

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -42,6 +42,7 @@ ExpReplaceDict = dict[int, Union[str, None]]
 
 
 class FormatOptions:
+    # TODO: __repr__
     """
     :class:`FormatOptions` stores all the configuration options used to
     format numbers and number/uncertainty pairs. See

--- a/src/sciform/formatter.py
+++ b/src/sciform/formatter.py
@@ -148,10 +148,9 @@ class Formatter:
         return self.format(value, uncertainty)
 
     def format(self, value: Number, uncertainty: Number = None, /):
-        rendered_format_options = self.format_options.render()
         if uncertainty is None:
-            return format_num(Decimal(str(value)), rendered_format_options)
+            return format_num(Decimal(str(value)), self.format_options)
         else:
             return format_val_unc(Decimal(str(value)),
                                   Decimal(str(uncertainty)),
-                                  rendered_format_options)
+                                  self.format_options)

--- a/src/sciform/formatter.py
+++ b/src/sciform/formatter.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from sciform.format_options import FormatOptions
 from sciform.formatting import format_num, format_val_unc
 from sciform.format_utils import Number
 
@@ -11,6 +12,8 @@ class Formatter:
     :class:`FormatOptions`. Any unpopulated format options will be
     populated from the global default options at format time. See
     :ref:`formatting_options` for more details on the available options.
+    If no options are provided then the global default options are used
+    for all options.
 
     >>> from sciform import FormatOptions, Formatter, ExpMode, RoundMode
     >>> sform = Formatter(FormatOptions(
@@ -33,7 +36,10 @@ class Formatter:
     :param format_options: :class:`FormatOptions` indicating which
       format options should be used for formatting.
     """
-    def __init__(self, format_options):
+    def __init__(self, format_options=None):
+        if format_options is None:
+            # TODO: Test this
+            format_options = FormatOptions()
         self.format_options = format_options
 
     def __call__(self, value: Number, uncertainty: Number = None, /):

--- a/src/sciform/formatter.py
+++ b/src/sciform/formatter.py
@@ -6,140 +6,32 @@ from sciform.format_utils import Number
 
 class Formatter:
     """
-    Formatter object used to convert numbers and pairs of numbers into
-    formatted strings. See :ref:`formatting_options` for more details on
-    the available options. Any options which are not provided by the
-    user will be filled with the corresponding values from the global
-    default configuration.
+    :class:`Formatter` is used to convert numbers and pairs of numbers
+    into formatted strings. Formatting options are configured using
+    :class:`FormatOptions`. Any unpopulated format options will be
+    populated from the global default options at format time. See
+    :ref:`formatting_options` for more details on the available options.
 
-    >>> from sciform import Formatter, ExpMode, RoundMode
-    >>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-    ...                   round_mode=RoundMode.SIG_FIG,
-    ...                   precision=4)
+    >>> from sciform import FormatOptions, Formatter, ExpMode, RoundMode
+    >>> sform = Formatter(FormatOptions(
+    ...             exp_mode=ExpMode.ENGINEERING,
+    ...             round_mode=RoundMode.SIG_FIG,
+    ...             precision=4))
     >>> print(sform(12345.678))
     12.35e+03
 
     The Formatter can be called with two aguments for value/uncertainty
     formatting
 
-    >>> sform = Formatter(exp_mode=ExpMode.ENGINEERING,
-    ...                   round_mode=RoundMode.SIG_FIG,
-    ...                   precision=2)
+    >>> sform = Formatter(FormatOptions(
+    ...             exp_mode=ExpMode.ENGINEERING,
+    ...             round_mode=RoundMode.SIG_FIG,
+    ...             precision=2))
     >>> print(sform(12345.678, 3.4))
     (12.3457 +/- 0.0034)e+03
 
-    The following checks are performed when creating a
-    :class:`Formatter` object:
-
-    * ``precision`` >= 1 for significant figure rounding mode
-    * ``exp`` must be consistent with the exponent mode:
-
-      * ``exp`` must be 0 for fixed point and percent modes
-      * ``exp`` must be a multiple of 3 for engineering and shifted
-        engineering modes
-      * ``exp`` must be a multiple of 10 for binary iec mode
-
-    * ``upper_separator`` may be any :class:`GroupingSeparator` but must
-      be different from ``decimal_separator``
-    * ``decimal_separator`` may only be :class:`GroupingSeparator.POINT`
-      or :class:`GroupingSeparator.COMMA`
-    * ``lower_separator`` may only be :class:`GroupingSeparator.NONE`,
-      :class:`GroupingSeparator.SPACE`, or
-      :class:`GroupingSeparator.UNDERSCORE`
-
-    :param fill_mode: :class:`FillMode` indicating whether
-      to fill with zeros or spaces.
-    :param sign_mode: :class:`SignMode` indicating sign
-      symbol behavior.
-    :param top_dig_place: Positive ``int`` indicating the digits place
-      to which the string will be left padded before the sign symbol. 0
-      corresponds to the ones place, 1 corresponds to the tens place
-      etc. E.g. ``top_dig_place=4`` will convert ``12`` into ``00012``.
-    :param upper_separator: :class:`GroupingSeparator` indicating the
-      character to be used to group digits above the decimal symbol.
-    :param decimal_separator: :class:`GroupingSeparator` indicating
-      the character to be used as the decimal symbol.
-      :class:`GroupingSeparator.POINT` or
-      :class:`GroupingSeparator.COMMA`. Note that ``decimal_separator``
-      cannot be the same as ``upper_separator``
-    :param lower_separator: :class:`GroupingSeparator` indicating the
-      character to be used to group digits below the decimal symbol.
-      :class:`GroupingSeparator.NONE`, :class:`GroupingSeparator.SPACE`,
-      or :class:`GroupingSeparator.UNDERSCORE`.
-    :param round_mode: :class:`RoundMode` indicating whether to round
-      the number based on significant figures or digits past the
-      decimal point
-    :param precision: :class:`int` or :class:`AutoPrec` sentinel indicating
-      how many significant figures or digits past the decimal point to
-      include for rounding. Must be >= 1 for significant figure
-      rounding. May be any integer for digits-past-the-decimal rounding.
-    :param exp_mode: :class:`ExpMode` indicating the formatting
-      mode to be used.
-    :param exp: :class:`int` or :class:`AutoExp` indicating the value which
-      should be used for the exponent. This parameter is ignored for the
-      fixed point exponent mode. For engineering, engineering shifted,
-      and binary iec modes, if this parameter is not consistent with the
-      rules of that mode (e.g. if it is not a multiple of 3), then the
-      exponent is rounded down to the nearest conforming value and a
-      warning is printed.
-    :param capitalize: :class:`bool` indicating whether the exponentiation
-      symbol should be upper- or lower-case.
-    :param percent: :class:`bool` indicating whether the number should be
-      formatted as a percentage or not. Only valid for fixed point
-      exponent mode. When ``True``, the number is multipled by 100 and
-      a ``%`` symbol is appended to the end of the string after
-      formatting.
-    :param superscript_exp: :class:`bool` indicating if the exponent string
-      should be converted into superscript notation. E.g. ``'1.23e+02'``
-      is converted to ``'1.23×10²'``
-    :param latex: :class:`bool` indicating if the resulting string should be
-      converted into a latex parseable code, e.g.
-      ``'\\left(1.23 \\pm 0.01\\right)\\times 10^{2}'``.
-    :param nan_inf_exp: :class:`bool` indicating whether non-finite numbers
-      such as ``float('nan')`` or ``float('inf')`` should be formatted
-      with exponent symbols when exponent modes including exponent
-      symbols are selected.
-    :param prefix_exp: :class:`bool` indicating if exponents should be
-      replaced with either SI or IEC prefixes as appropriate.
-    :param parts_per_exp: :class:`bool` indicating if "parts-per" exponent
-      translations should be used.
-    :param extra_si_prefixes: ``dict[int, Union[str, None]]`` mapping
-      additional exponent values to si prefixes. Entries overwrite
-      default values. A value of ``None`` means that exponent will not
-      be converted.
-    :param extra_iec_prefixes: ``dict[int, Union[str, None]]`` mapping
-      additional exponent values to iec prefixes. Entries overwrite
-      default values. A value of ``None`` means that exponent will not
-      be converted.
-    :param extra_parts_per_forms: ``dict[int, Union[str, None]]``
-      mapping additional exponent values to "parts-per" forms. Entries
-      overwrite default values. A value of ``None`` means that exponent
-      will not be converted.
-    :param add_c_prefix: :class:`bool` (default ``False``) if ``True`` adds
-      ``{-2: 'c'}`` to ``extra_si_prefixes``.
-    :param add_small_si_prefixes: ``bool`` (default ``False``) if
-      ``True`` adds ``{-2: 'c', -1: 'd', +1: 'da', +2: 'h'}`` to
-      ``extra_si_prefixes``.
-    :param add_ppth_form: :class:`bool` (default ``False``) if ``True`` adds
-      ``{-3: 'ppth'}`` to ``extra_parts_per_forms``.
-    :param pdg_sig_figs: :class:`bool` indicating whether the
-      particle-data-group conventions should be used to automatically
-      determine the number of significant figures to use for
-      uncertainty.
-    :param bracket_unc: :class:`bool` indicating if bracket uncertainty mode
-      (e.g. ``12.34(82)`` instead of ``12.34 +/- 0.82``) should be used.
-    :param val_unc_match_widths: :class:`bool` indicating if the value or
-      uncertainty should be left padded to ensure they are both left
-      padded to the same digits place.
-    :param bracket_unc_remove_seps: :class:`bool` indicating if separator
-      symbols should be removed from the uncertainty when using bracket
-      uncertainty mode. E.g. expressing ``123.4 +/- 2.3`` as
-      ``123.4(23)`` instead of ``123.4(2.3)``.
-    :param unicode_pm: :class:`bool` indicating if the '+/-' separator should
-      be replaced with the unicode plus minus symbol '±'.
-    :param unc_pm_whitespace: :class:`bool` indicating if there should be
-      whitespace surrounding the ``'+/-'`` symbols when formatting. E.g.
-      ``123.4+/-2.3`` compared to ``123.4 +/- 2.3``.
+    :param format_options: :class:`FormatOptions` indicating which
+      format options should be used for formatting.
     """
     def __init__(self, format_options):
         self.format_options = format_options

--- a/src/sciform/formatter.py
+++ b/src/sciform/formatter.py
@@ -1,10 +1,5 @@
-from typing import Union
 from decimal import Decimal
 
-from sciform.modes import (SignMode, FillMode, UpperGroupingSeparators,
-                           DecimalGroupingSeparators, LowerGroupingSeparators,
-                           ExpMode, RoundMode, AutoExp, AutoPrec)
-from sciform.format_options import FormatOptions
 from sciform.formatting import format_num, format_val_unc
 from sciform.format_utils import Number
 
@@ -146,109 +141,17 @@ class Formatter:
       whitespace surrounding the ``'+/-'`` symbols when formatting. E.g.
       ``123.4+/-2.3`` compared to ``123.4 +/- 2.3``.
     """
-    def __init__(
-            self,
-            *,
-            fill_mode: FillMode = None,
-            sign_mode: SignMode = None,
-            top_dig_place: int = None,
-            upper_separator: UpperGroupingSeparators = None,
-            decimal_separator: DecimalGroupingSeparators = None,
-            lower_separator: LowerGroupingSeparators = None,
-            round_mode: RoundMode = None,
-            precision: Union[int, type(AutoPrec)] = None,
-            exp_mode: ExpMode = None,
-            exp: Union[int, type(AutoExp)] = None,
-            capitalize: bool = None,
-            percent: bool = None,
-            superscript_exp: bool = None,
-            latex: bool = None,
-            nan_inf_exp: bool = None,
-            prefix_exp: bool = None,
-            parts_per_exp: bool = None,
-            extra_si_prefixes: dict[int, Union[str, None]] = None,
-            extra_iec_prefixes: dict[int, Union[str, None]] = None,
-            extra_parts_per_forms: dict[int, Union[str, None]] = None,
-            add_c_prefix: bool = False,
-            add_small_si_prefixes: bool = False,
-            add_ppth_form: bool = False,
-            pdg_sig_figs: bool = None,
-            bracket_unc: bool = None,
-            val_unc_match_widths: bool = None,
-            bracket_unc_remove_seps: bool = None,
-            unicode_pm: bool = None,
-            unc_pm_whitespace: bool = None
-    ):
-        self.options = FormatOptions.make(
-            defaults=None,
-            fill_mode=fill_mode,
-            sign_mode=sign_mode,
-            top_dig_place=top_dig_place,
-            upper_separator=upper_separator,
-            decimal_separator=decimal_separator,
-            lower_separator=lower_separator,
-            round_mode=round_mode,
-            precision=precision,
-            exp_mode=exp_mode,
-            exp=exp,
-            capitalize=capitalize,
-            percent=percent,
-            superscript_exp=superscript_exp,
-            latex=latex,
-            nan_inf_exp=nan_inf_exp,
-            prefix_exp=prefix_exp,
-            parts_per_exp=parts_per_exp,
-            extra_si_prefixes=extra_si_prefixes,
-            extra_iec_prefixes=extra_iec_prefixes,
-            extra_parts_per_forms=extra_parts_per_forms,
-            add_c_prefix=add_c_prefix,
-            add_small_si_prefixes=add_small_si_prefixes,
-            add_ppth_form=add_ppth_form,
-            pdg_sig_figs=pdg_sig_figs,
-            bracket_unc=bracket_unc,
-            val_unc_match_widths=val_unc_match_widths,
-            bracket_unc_remove_seps=bracket_unc_remove_seps,
-            unicode_pm=unicode_pm,
-            unc_pm_whitespace=unc_pm_whitespace
-        )
+    def __init__(self, format_options):
+        self.format_options = format_options
 
     def __call__(self, value: Number, uncertainty: Number = None, /):
         return self.format(value, uncertainty)
 
     def format(self, value: Number, uncertainty: Number = None, /):
+        rendered_format_options = self.format_options.render()
         if uncertainty is None:
-            return format_num(Decimal(str(value)), self.options)
+            return format_num(Decimal(str(value)), rendered_format_options)
         else:
             return format_val_unc(Decimal(str(value)),
                                   Decimal(str(uncertainty)),
-                                  self.options)
-
-    # TODO: What is this for? Remove this.
-    @classmethod
-    def _from_options(cls, options: FormatOptions):
-        return cls(fill_mode=options.fill_mode,
-                   sign_mode=options.sign_mode,
-                   top_dig_place=options.top_dig_place,
-                   upper_separator=options.upper_separator,
-                   decimal_separator=options.decimal_separator,
-                   lower_separator=options.lower_separator,
-                   round_mode=options.round_mode,
-                   precision=options.precision,
-                   exp_mode=options.exp_mode,
-                   exp=options.exp,
-                   capitalize=options.capitalize,
-                   percent=options.percent,
-                   superscript_exp=options.superscript_exp,
-                   latex=options.latex,
-                   nan_inf_exp=options.nan_inf_exp,
-                   prefix_exp=options.prefix_exp,
-                   parts_per_exp=options.parts_per_exp,
-                   extra_si_prefixes=options.extra_si_prefixes,
-                   extra_iec_prefixes=options.extra_iec_prefixes,
-                   extra_parts_per_forms=options.extra_parts_per_forms,
-                   pdg_sig_figs=options.pdg_sig_figs,
-                   bracket_unc=options.bracket_unc,
-                   val_unc_match_widths=options.val_unc_match_widths,
-                   bracket_unc_remove_seps=options.bracket_unc_remove_seps,
-                   unicode_pm=options.unicode_pm,
-                   unc_pm_whitespace=options.unc_pm_whitespace)
+                                  rendered_format_options)

--- a/src/sciform/formatting.py
+++ b/src/sciform/formatting.py
@@ -2,8 +2,8 @@ from warnings import warn
 import re
 from decimal import Decimal
 
-from sciform.modes import ExpMode, SignMode, AutoExp
-from sciform.format_options import FormatOptions, RoundMode
+from sciform.modes import ExpMode, SignMode, AutoExp, RoundMode
+from sciform.format_options import FormatOptions, RenderedFormatOptions
 from sciform.format_utils import (get_mantissa_exp_base, get_exp_str,
                                   get_top_digit,
                                   get_round_digit,
@@ -13,7 +13,7 @@ from sciform.format_utils import (get_mantissa_exp_base, get_exp_str,
 from sciform.grouping import add_separators
 
 
-def format_non_inf(num: Decimal, options: FormatOptions) -> str:
+def format_non_inf(num: Decimal, options: RenderedFormatOptions) -> str:
     if num.is_nan():
         num_str = 'nan'
     elif num == Decimal('inf'):
@@ -69,7 +69,7 @@ def format_non_inf(num: Decimal, options: FormatOptions) -> str:
     return result
 
 
-def format_num(num: Decimal, options: FormatOptions) -> str:
+def format_num(num: Decimal, options: RenderedFormatOptions) -> str:
     if not num.is_finite():
         return format_non_inf(num, options)
 
@@ -140,7 +140,7 @@ def format_num(num: Decimal, options: FormatOptions) -> str:
     return result
 
 
-def format_val_unc(val: Decimal, unc: Decimal, options: FormatOptions):
+def format_val_unc(val: Decimal, unc: Decimal, options: RenderedFormatOptions):
     if options.round_mode is RoundMode.PREC:
         warn('Precision round mode not available for value/uncertainty '
              'formatting. Rounding is always applied as significant figures '
@@ -254,8 +254,8 @@ def format_val_unc(val: Decimal, unc: Decimal, options: FormatOptions):
          'e+03' or similar. Such translations are handled within the
          scope of this function.
     '''
-    val_format_options = FormatOptions.make(
-        defaults=options,
+    val_format_options = FormatOptions(
+        template=options,
         top_dig_place=new_top_digit,
         round_mode=RoundMode.PREC,
         precision=prec,
@@ -266,12 +266,12 @@ def format_val_unc(val: Decimal, unc: Decimal, options: FormatOptions):
         latex=False,
         prefix_exp=False,
         parts_per_exp=False
-    )
+    ).render()
 
-    unc_format_options = FormatOptions.make(
-        defaults=val_format_options,
+    unc_format_options = FormatOptions(
+        template=val_format_options,
         sign_mode=SignMode.NEGATIVE,
-    )
+    ).render()
 
     # Optional parentheses needed to handle (nan)e+00 case
     mantissa_exp_pattern = re.compile(

--- a/src/sciform/formatting.py
+++ b/src/sciform/formatting.py
@@ -69,7 +69,9 @@ def format_non_inf(num: Decimal, options: RenderedFormatOptions) -> str:
     return result
 
 
-def format_num(num: Decimal, options: RenderedFormatOptions) -> str:
+def format_num(num: Decimal, unrendered_options: FormatOptions) -> str:
+    options = unrendered_options.render()
+
     if not num.is_finite():
         return format_non_inf(num, options)
 
@@ -140,7 +142,10 @@ def format_num(num: Decimal, options: RenderedFormatOptions) -> str:
     return result
 
 
-def format_val_unc(val: Decimal, unc: Decimal, options: RenderedFormatOptions):
+def format_val_unc(val: Decimal, unc: Decimal,
+                   unrendered_options: FormatOptions):
+    options = unrendered_options.render()
+
     if options.round_mode is RoundMode.PREC:
         warn('Precision round mode not available for value/uncertainty '
              'formatting. Rounding is always applied as significant figures '
@@ -255,7 +260,7 @@ def format_val_unc(val: Decimal, unc: Decimal, options: RenderedFormatOptions):
          scope of this function.
     '''
     val_format_options = FormatOptions(
-        template=options,
+        template=unrendered_options,
         top_dig_place=new_top_digit,
         round_mode=RoundMode.PREC,
         precision=prec,
@@ -266,12 +271,12 @@ def format_val_unc(val: Decimal, unc: Decimal, options: RenderedFormatOptions):
         latex=False,
         prefix_exp=False,
         parts_per_exp=False
-    ).render()
+    )
 
     unc_format_options = FormatOptions(
         template=val_format_options,
         sign_mode=SignMode.NEGATIVE,
-    ).render()
+    )
 
     # Optional parentheses needed to handle (nan)e+00 case
     mantissa_exp_pattern = re.compile(

--- a/src/sciform/fsml.py
+++ b/src/sciform/fsml.py
@@ -1,0 +1,148 @@
+import re
+
+from sciform.format_options import FormatOptions, Free
+from sciform.modes import (FillMode, SignMode, GroupingSeparator, RoundMode,
+                           ExpMode)
+
+
+pattern = re.compile(r'''^
+                         (?:(?P<fill_mode>[ 0])=)?
+                         (?P<sign_mode>[-+ ])?
+                         (?P<alternate_mode>\#)?
+                         (?P<top_dig_place>\d+)?
+                         (?P<upper_separator>[n,.s_])?
+                         (?P<decimal_separator>[.,])?
+                         (?P<lower_separator>[ns_])?
+                         (?:(?P<round_mode>[.!])(?P<prec>[+-]?\d+))?
+                         (?P<exp_mode>[fF%eErRbB])?
+                         (?:x(?P<exp>[+-]?\d+))?
+                         (?P<prefix_mode>p)?
+                         (?P<bracket_unc>\(\))?
+                         $''', re.VERBOSE)
+
+fill_mode_mapping = {' ': FillMode.SPACE,
+                     '0': FillMode.ZERO,
+                     None: Free()}
+
+sign_mode_mapping = {'-': SignMode.NEGATIVE,
+                     '+': SignMode.ALWAYS,
+                     ' ': SignMode.SPACE,
+                     None: Free()}
+
+separator_mapping = {'n': GroupingSeparator.NONE,
+                     ',': GroupingSeparator.COMMA,
+                     '.': GroupingSeparator.POINT,
+                     's': GroupingSeparator.SPACE,
+                     '_': GroupingSeparator.UNDERSCORE,
+                     None: Free()}
+
+round_mode_mapping = {'!': RoundMode.SIG_FIG,
+                      '.': RoundMode.PREC,
+                      None: Free()}
+
+
+def format_options_from_fmt_spec(fmt_spec: str) -> 'FormatOptions':
+    match = pattern.match(fmt_spec)
+    if match is None:
+        raise ValueError(f'Invalid format specifier: \'{fmt_spec}\'')
+
+    fill_mode_flag = match.group('fill_mode')
+    if fill_mode_flag is not None:
+        fill_mode = fill_mode_mapping[fill_mode_flag]
+    else:
+        fill_mode = Free()
+
+    sign_mode_flag = match.group('sign_mode')
+    if sign_mode_flag is not None:
+        sign_mode = sign_mode_mapping[sign_mode_flag]
+    else:
+        sign_mode = Free()
+
+    alternate_mode = match.group('alternate_mode')
+    alternate_mode = alternate_mode is not None
+
+    top_dig_place = match.group('top_dig_place')
+    if top_dig_place is not None:
+        top_dig_place = int(top_dig_place)
+        val_unc_match_widths = True
+    else:
+        top_dig_place = Free()
+        val_unc_match_widths = Free()
+
+    upper_separator_flag = match.group('upper_separator')
+    upper_separator = separator_mapping[upper_separator_flag]
+
+    decimal_separator_flag = match.group('decimal_separator')
+    decimal_separator = separator_mapping[decimal_separator_flag]
+
+    lower_separator_flag = match.group('lower_separator')
+    lower_separator = separator_mapping[lower_separator_flag]
+
+    round_mode_flag = match.group('round_mode')
+    round_mode = round_mode_mapping[round_mode_flag]
+
+    precision = match.group('prec')
+    if precision is not None:
+        precision = int(precision)
+    else:
+        precision = Free()
+
+    percent = Free()
+    exp_mode = match.group('exp_mode')
+    if exp_mode is not None:
+        capitalize = exp_mode.isupper()
+        if exp_mode in ['f', 'F', '%']:
+            if exp_mode == '%':
+                percent = True
+            exp_mode = ExpMode.FIXEDPOINT
+        elif exp_mode in ['e', 'E']:
+            exp_mode = ExpMode.SCIENTIFIC
+        elif exp_mode in ['r', 'R']:
+            if alternate_mode:
+                exp_mode = ExpMode.ENGINEERING_SHIFTED
+            else:
+                exp_mode = ExpMode.ENGINEERING
+        elif exp_mode in ['b', 'B']:
+            if alternate_mode:
+                exp_mode = ExpMode.BINARY_IEC
+            else:
+                exp_mode = ExpMode.BINARY
+    else:
+        capitalize = Free()
+        exp_mode = Free()
+
+    exp = match.group('exp')
+    if exp is not None:
+        exp = int(exp)
+    else:
+        exp = Free()
+
+    prefix_exp = match.group('prefix_mode')
+    if prefix_exp is not None:
+        prefix_exp = True
+    else:
+        prefix_exp = Free()
+
+    bracket_unc = match.group('bracket_unc')
+    if bracket_unc is not None:
+        bracket_unc = True
+    else:
+        bracket_unc = Free()
+
+    return FormatOptions(
+        fill_mode=fill_mode,
+        sign_mode=sign_mode,
+        top_dig_place=top_dig_place,
+        upper_separator=upper_separator,
+        decimal_separator=decimal_separator,
+        lower_separator=lower_separator,
+        round_mode=round_mode,
+        precision=precision,
+        exp_mode=exp_mode,
+        exp=exp,
+        percent=percent,
+        capitalize=capitalize,
+        prefix_exp=prefix_exp,
+        bracket_unc=bracket_unc,
+        val_unc_match_widths=val_unc_match_widths
+    )

--- a/src/sciform/fsml.py
+++ b/src/sciform/fsml.py
@@ -1,6 +1,6 @@
 import re
 
-from sciform.format_options import FormatOptions, Free
+from sciform.format_options import FormatOptions
 from sciform.modes import (FillMode, SignMode, GroupingSeparator, RoundMode,
                            ExpMode)
 
@@ -22,23 +22,23 @@ pattern = re.compile(r'''^
 
 fill_mode_mapping = {' ': FillMode.SPACE,
                      '0': FillMode.ZERO,
-                     None: Free()}
+                     None: None}
 
 sign_mode_mapping = {'-': SignMode.NEGATIVE,
                      '+': SignMode.ALWAYS,
                      ' ': SignMode.SPACE,
-                     None: Free()}
+                     None: None}
 
 separator_mapping = {'n': GroupingSeparator.NONE,
                      ',': GroupingSeparator.COMMA,
                      '.': GroupingSeparator.POINT,
                      's': GroupingSeparator.SPACE,
                      '_': GroupingSeparator.UNDERSCORE,
-                     None: Free()}
+                     None: None}
 
 round_mode_mapping = {'!': RoundMode.SIG_FIG,
                       '.': RoundMode.PREC,
-                      None: Free()}
+                      None: None}
 
 
 def format_options_from_fmt_spec(fmt_spec: str) -> 'FormatOptions':
@@ -50,13 +50,13 @@ def format_options_from_fmt_spec(fmt_spec: str) -> 'FormatOptions':
     if fill_mode_flag is not None:
         fill_mode = fill_mode_mapping[fill_mode_flag]
     else:
-        fill_mode = Free()
+        fill_mode = None
 
     sign_mode_flag = match.group('sign_mode')
     if sign_mode_flag is not None:
         sign_mode = sign_mode_mapping[sign_mode_flag]
     else:
-        sign_mode = Free()
+        sign_mode = None
 
     alternate_mode = match.group('alternate_mode')
     alternate_mode = alternate_mode is not None
@@ -66,8 +66,8 @@ def format_options_from_fmt_spec(fmt_spec: str) -> 'FormatOptions':
         top_dig_place = int(top_dig_place)
         val_unc_match_widths = True
     else:
-        top_dig_place = Free()
-        val_unc_match_widths = Free()
+        top_dig_place = None
+        val_unc_match_widths = None
 
     upper_separator_flag = match.group('upper_separator')
     upper_separator = separator_mapping[upper_separator_flag]
@@ -85,9 +85,9 @@ def format_options_from_fmt_spec(fmt_spec: str) -> 'FormatOptions':
     if precision is not None:
         precision = int(precision)
     else:
-        precision = Free()
+        precision = None
 
-    percent = Free()
+    percent = None
     exp_mode = match.group('exp_mode')
     if exp_mode is not None:
         capitalize = exp_mode.isupper()
@@ -108,26 +108,26 @@ def format_options_from_fmt_spec(fmt_spec: str) -> 'FormatOptions':
             else:
                 exp_mode = ExpMode.BINARY
     else:
-        capitalize = Free()
-        exp_mode = Free()
+        capitalize = None
+        exp_mode = None
 
     exp = match.group('exp')
     if exp is not None:
         exp = int(exp)
     else:
-        exp = Free()
+        exp = None
 
     prefix_exp = match.group('prefix_mode')
     if prefix_exp is not None:
         prefix_exp = True
     else:
-        prefix_exp = Free()
+        prefix_exp = None
 
     bracket_unc = match.group('bracket_unc')
     if bracket_unc is not None:
         bracket_unc = True
     else:
-        bracket_unc = Free()
+        bracket_unc = None
 
     return FormatOptions(
         fill_mode=fill_mode,

--- a/src/sciform/scinum.py
+++ b/src/sciform/scinum.py
@@ -20,9 +20,9 @@ class SciNum:
         self.value = Decimal(str(value))
 
     def __format__(self, fmt: str):
-        rendered_format_options = format_options_from_fmt_spec(fmt).render()
+        format_options = format_options_from_fmt_spec(fmt)
         return format_num(self.value,
-                          rendered_format_options)
+                          format_options)
 
     def __repr__(self):
         return f'{self.__class__.__name__}({self.value})'
@@ -47,10 +47,10 @@ class SciNumUnc:
         self.uncertainty = Decimal(str(uncertainty))
 
     def __format__(self, fmt: str):
-        rendered_format_options = format_options_from_fmt_spec(fmt).render()
+        format_options = format_options_from_fmt_spec(fmt)
         return format_val_unc(self.value,
                               self.uncertainty,
-                              rendered_format_options)
+                              format_options)
 
     def __repr__(self):
         return f'{self.__class__.__name__}({self.value}, {self.uncertainty})'

--- a/src/sciform/scinum.py
+++ b/src/sciform/scinum.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from sciform.formatting import format_num, format_val_unc
 from sciform.format_utils import Number
-from sciform.format_options import FormatOptions
+from sciform.fsml import format_options_from_fmt_spec
 
 
 class SciNum:
@@ -20,8 +20,9 @@ class SciNum:
         self.value = Decimal(str(value))
 
     def __format__(self, fmt: str):
+        rendered_format_options = format_options_from_fmt_spec(fmt).render()
         return format_num(self.value,
-                          FormatOptions.from_format_spec_str(fmt))
+                          rendered_format_options)
 
     def __repr__(self):
         return f'{self.__class__.__name__}({self.value})'
@@ -45,10 +46,11 @@ class SciNumUnc:
         self.value = Decimal(str(value))
         self.uncertainty = Decimal(str(uncertainty))
 
-    def __format__(self, format_spec: str):
+    def __format__(self, fmt: str):
+        rendered_format_options = format_options_from_fmt_spec(fmt).render()
         return format_val_unc(self.value,
                               self.uncertainty,
-                              FormatOptions.from_format_spec_str(format_spec))
+                              rendered_format_options)
 
     def __repr__(self):
         return f'{self.__class__.__name__}({self.value}, {self.uncertainty})'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,18 +1,19 @@
 import unittest
 
 from sciform import (SciNum, GlobalDefaultsContext, ExpMode,
-                     GroupingSeparator, RoundMode, SignMode)
+                     GroupingSeparator, RoundMode, SignMode, FormatOptions)
 
 
 class TestConfig(unittest.TestCase):
     def test_global_defaults_context(self):
         num = SciNum(123.456)
         before_str = f'{num}'
-        with GlobalDefaultsContext(sign_mode=SignMode.ALWAYS,
-                                   exp_mode=ExpMode.SCIENTIFIC,
-                                   round_mode=RoundMode.SIG_FIG,
-                                   precision=2,
-                                   decimal_separator=GroupingSeparator.COMMA):
+        with GlobalDefaultsContext(FormatOptions(
+                sign_mode=SignMode.ALWAYS,
+                exp_mode=ExpMode.SCIENTIFIC,
+                round_mode=RoundMode.SIG_FIG,
+                precision=2,
+                decimal_separator=GroupingSeparator.COMMA)):
             during_str = f'{num}'
         after_str = f'{num}'
 
@@ -25,7 +26,7 @@ class TestConfig(unittest.TestCase):
 
     def test_c_prefix(self):
         num = SciNum(123.456)
-        with GlobalDefaultsContext(add_c_prefix=True):
+        with GlobalDefaultsContext(FormatOptions(add_c_prefix=True)):
             num_str = f'{num:ex-2p}'
 
         expected_num_str = '12345.6 c'
@@ -40,7 +41,7 @@ class TestConfig(unittest.TestCase):
                       +1: '12.3456 da',
                       +2: '1.23456 h'}
 
-        with GlobalDefaultsContext(add_small_si_prefixes=True):
+        with GlobalDefaultsContext(FormatOptions(add_small_si_prefixes=True)):
             for exp, expected_num_str in cases_dict.items():
                 num_str = f'{num:ex{exp:+}p}'
                 self.assertEqual(num_str, expected_num_str)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import unittest
 
-from sciform import (SciNum, GlobalDefaultsContext, ExpMode,
-                     GroupingSeparator, RoundMode, SignMode, FormatOptions)
+from sciform import (FormatOptions, SciNum, GlobalDefaultsContext, ExpMode,
+                     GroupingSeparator, RoundMode, SignMode)
 
 
 class TestConfig(unittest.TestCase):

--- a/tests/test_float_formatter.py
+++ b/tests/test_float_formatter.py
@@ -1,7 +1,7 @@
 import unittest
 
-from sciform import (FormatOptions, Formatter,
-                     ExpMode, GroupingSeparator, FillMode)
+from sciform import (FormatOptions, Formatter, ExpMode, GroupingSeparator,
+                     FillMode)
 
 
 FloatFormatOptionsCases = list[tuple[float, list[tuple[FormatOptions, str]]]]

--- a/tests/test_float_formatter.py
+++ b/tests/test_float_formatter.py
@@ -1,15 +1,17 @@
 import unittest
 
-from sciform import Formatter, ExpMode, GroupingSeparator, FillMode
+from sciform import (FormatOptions, Formatter,
+                     ExpMode, GroupingSeparator, FillMode)
 
 
-FloatFormatterCases = list[tuple[float, list[tuple[Formatter, str]]]]
+FloatFormatOptionsCases = list[tuple[float, list[tuple[FormatOptions, str]]]]
 
 
 class TestFormatting(unittest.TestCase):
-    def run_float_formatter_cases(self, cases_list: FloatFormatterCases):
+    def run_float_formatter_cases(self, cases_list: FloatFormatOptionsCases):
         for num, formats_list in cases_list:
-            for formatter, expected_num_str in formats_list:
+            for format_options, expected_num_str in formats_list:
+                formatter = Formatter(format_options)
                 snum_str = formatter(num)
                 with self.subTest(num=num,
                                   expected_num_str=expected_num_str,
@@ -19,8 +21,8 @@ class TestFormatting(unittest.TestCase):
     def test_superscript_exp(self):
         cases_list = [
             (789, [
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           superscript_exp=True), '7.89×10²')
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               superscript_exp=True), '7.89×10²')
             ])
         ]
 
@@ -29,24 +31,24 @@ class TestFormatting(unittest.TestCase):
     def test_fill_and_separators(self):
         cases_list = [
             (123456789.654321, [
-                (Formatter(
+                (FormatOptions(
                     upper_separator=GroupingSeparator.UNDERSCORE,
                     lower_separator=GroupingSeparator.UNDERSCORE,
                     fill_mode=FillMode.ZERO,
                     top_dig_place=14), '000_000_123_456_789.654_321'),
-                (Formatter(
+                (FormatOptions(
                     upper_separator=GroupingSeparator.UNDERSCORE,
                     lower_separator=GroupingSeparator.UNDERSCORE,
                     fill_mode=FillMode.SPACE,
                     top_dig_place=14), '      123_456_789.654_321'),
             ]),
             (4567899.7654321, [
-                (Formatter(
+                (FormatOptions(
                     upper_separator=GroupingSeparator.UNDERSCORE,
                     lower_separator=GroupingSeparator.UNDERSCORE,
                     fill_mode=FillMode.ZERO,
                     top_dig_place=14), '000_000_004_567_899.765_432_1'),
-                (Formatter(
+                (FormatOptions(
                     upper_separator=GroupingSeparator.UNDERSCORE,
                     lower_separator=GroupingSeparator.UNDERSCORE,
                     fill_mode=FillMode.SPACE,
@@ -59,23 +61,23 @@ class TestFormatting(unittest.TestCase):
     def test_latex(self):
         cases_list = [
             (789, [
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           latex=True), r'7.89\times 10^{+2}'),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               latex=True), r'7.89\times 10^{+2}'),
 
                 # Latex mode takes precedence over superscript_exp
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           latex=True,
-                           superscript_exp=True), r'7.89\times 10^{+2}')
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               latex=True,
+                               superscript_exp=True), r'7.89\times 10^{+2}')
             ]),
             (12345, [
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-1,
-                           upper_separator=GroupingSeparator.UNDERSCORE,
-                           latex=True), r'123\_450\times 10^{-1}'),
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=3,
-                           prefix_exp=True,
-                           latex=True), r'12.345\text{k}')
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-1,
+                               upper_separator=GroupingSeparator.UNDERSCORE,
+                               latex=True), r'123\_450\times 10^{-1}'),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=3,
+                               prefix_exp=True,
+                               latex=True), r'12.345\text{k}')
             ])
         ]
 
@@ -84,9 +86,9 @@ class TestFormatting(unittest.TestCase):
     def test_nan(self):
         cases_list = [
             (float('nan'), [
-                (Formatter(percent=True), '(nan)%'),
-                (Formatter(percent=True,
-                           latex=True), r'\left(nan\right)\%')
+                (FormatOptions(percent=True), '(nan)%'),
+                (FormatOptions(percent=True,
+                               latex=True), r'\left(nan\right)\%')
             ])
         ]
 
@@ -95,31 +97,31 @@ class TestFormatting(unittest.TestCase):
     def test_parts_per_exp(self):
         cases_list = [
             (123e-3, [
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-3,
-                           parts_per_exp=True,
-                           add_ppth_form=True), '123 ppth'),
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-6,
-                           parts_per_exp=True), '123000 ppm'),
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-2,
-                           parts_per_exp=True), '12.3e-02')
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-3,
+                               parts_per_exp=True,
+                               add_ppth_form=True), '123 ppth'),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-6,
+                               parts_per_exp=True), '123000 ppm'),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-2,
+                               parts_per_exp=True), '12.3e-02')
             ]),
             (123e-9, [
-                (Formatter(exp_mode=ExpMode.ENGINEERING,
-                           parts_per_exp=True), '123 ppb'),
-                (Formatter(exp_mode=ExpMode.ENGINEERING,
-                           parts_per_exp=True,
-                           extra_parts_per_forms={-9: None, -12: 'ppb'}),
+                (FormatOptions(exp_mode=ExpMode.ENGINEERING,
+                               parts_per_exp=True), '123 ppb'),
+                (FormatOptions(exp_mode=ExpMode.ENGINEERING,
+                               parts_per_exp=True,
+                               extra_parts_per_forms={-9: None, -12: 'ppb'}),
                  '123e-09')
             ]),
             (123e-12, [
-                (Formatter(exp_mode=ExpMode.ENGINEERING,
-                           parts_per_exp=True), '123 ppt'),
-                (Formatter(exp_mode=ExpMode.ENGINEERING,
-                           parts_per_exp=True,
-                           extra_parts_per_forms={-9: None, -12: 'ppb'}),
+                (FormatOptions(exp_mode=ExpMode.ENGINEERING,
+                               parts_per_exp=True), '123 ppt'),
+                (FormatOptions(exp_mode=ExpMode.ENGINEERING,
+                               parts_per_exp=True,
+                               extra_parts_per_forms={-9: None, -12: 'ppb'}),
                  '123 ppb')
             ])
         ]

--- a/tests/test_float_fsml.py
+++ b/tests/test_float_fsml.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sciform import SciNum, GlobalDefaultsContext
+from sciform import SciNum, GlobalDefaultsContext, FormatOptions
 
 
 FloatFSMLCases = list[tuple[float, list[tuple[str, str]]]]
@@ -408,7 +408,7 @@ class TestFormatting(unittest.TestCase):
             ])
         ]
 
-        with GlobalDefaultsContext(nan_inf_exp=True):
+        with GlobalDefaultsContext(FormatOptions(nan_inf_exp=True)):
             self.run_float_fsml_cases(cases_list)
 
     def test_separators(self):

--- a/tests/test_val_unc_formatter.py
+++ b/tests/test_val_unc_formatter.py
@@ -1,16 +1,17 @@
 import unittest
 
-from sciform import Formatter, ExpMode, GroupingSeparator
+from sciform import Formatter, ExpMode, GroupingSeparator, FormatOptions
 
 
-ValUncFormatterCases = list[tuple[tuple[float, float],
-                                  list[tuple[Formatter, str]]]]
+ValUncFormatOptionsCases = list[tuple[tuple[float, float],
+                                      list[tuple[FormatOptions, str]]]]
 
 
 class TestFormatting(unittest.TestCase):
-    def run_val_unc_formatter_cases(self, cases_list: ValUncFormatterCases):
+    def run_val_unc_formatter_cases(self, cases_list: ValUncFormatOptionsCases):
         for (val, unc), formats_list in cases_list:
-            for formatter, expected_val_unc_str in formats_list:
+            for format_options, expected_val_unc_str in formats_list:
+                formatter = Formatter(format_options)
                 snum_str = formatter(val, unc)
                 with self.subTest(val=val, unc=unc,
                                   expected_num_str=expected_val_unc_str,
@@ -20,19 +21,19 @@ class TestFormatting(unittest.TestCase):
     def test_bracket_unc(self):
         cases_list = [
             ((123.456, 0.789), [
-                (Formatter(bracket_unc=True), '123.456(789)'),
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           bracket_unc=True), '(1.23456(789))e+02'),
-                (Formatter(exp_mode=ExpMode.ENGINEERING,
-                           bracket_unc=True), '(123.456(789))e+00'),
-                (Formatter(exp_mode=ExpMode.ENGINEERING_SHIFTED,
-                           bracket_unc=True), '(0.123456(789))e+03'),
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=+1,
-                           bracket_unc=True), '(12.3456(789))e+01'),
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-1,
-                           bracket_unc=True), '(1234.56(7.89))e-01'),
+                (FormatOptions(bracket_unc=True), '123.456(789)'),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               bracket_unc=True), '(1.23456(789))e+02'),
+                (FormatOptions(exp_mode=ExpMode.ENGINEERING,
+                               bracket_unc=True), '(123.456(789))e+00'),
+                (FormatOptions(exp_mode=ExpMode.ENGINEERING_SHIFTED,
+                               bracket_unc=True), '(0.123456(789))e+03'),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=+1,
+                               bracket_unc=True), '(12.3456(789))e+01'),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-1,
+                               bracket_unc=True), '(1234.56(7.89))e-01'),
             ])
         ]
 
@@ -41,12 +42,12 @@ class TestFormatting(unittest.TestCase):
     def test_percent(self):
         cases_list = [
             ((0.123_456_78, 0.000_002_55), [
-                (Formatter(percent=True,
-                           lower_separator=GroupingSeparator.UNDERSCORE),
+                (FormatOptions(percent=True,
+                               lower_separator=GroupingSeparator.UNDERSCORE),
                  '(12.345_678 +/- 0.000_255)%'),
-                (Formatter(percent=True,
-                           bracket_unc=True,
-                           lower_separator=GroupingSeparator.UNDERSCORE),
+                (FormatOptions(percent=True,
+                               bracket_unc=True,
+                               lower_separator=GroupingSeparator.UNDERSCORE),
                  '(12.345_678(255))%')
             ])
         ]
@@ -56,21 +57,21 @@ class TestFormatting(unittest.TestCase):
     def test_bracket_unc_remove_dec_symb(self):
         cases_list = [
             ((123.456, 0.789), [
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-1,
-                           bracket_unc=True), '(1234.56(7.89))e-01'),
-                (Formatter(
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-1,
+                               bracket_unc=True), '(1234.56(7.89))e-01'),
+                (FormatOptions(
                     exp_mode=ExpMode.SCIENTIFIC,
                     exp=-1,
                     bracket_unc_remove_seps=True,
                     bracket_unc=True), '(1234.56(789))e-01'),
             ]),
             ((0.789, 123.456), [
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-1,
-                           bracket_unc=True), '(7.89(1234.56))e-01'),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-1,
+                               bracket_unc=True), '(7.89(1234.56))e-01'),
                 # Don't remove "embedded" decimal unless val > unc.
-                (Formatter(
+                (FormatOptions(
                     exp_mode=ExpMode.SCIENTIFIC,
                     exp=-1,
                     bracket_unc_remove_seps=True,
@@ -83,8 +84,8 @@ class TestFormatting(unittest.TestCase):
     def test_unc_pm_whitespace(self):
         cases_list = [
             ((123.456, 0.789), [
-                (Formatter(unc_pm_whitespace=True), '123.456 +/- 0.789'),
-                (Formatter(unc_pm_whitespace=False), '123.456+/-0.789')
+                (FormatOptions(unc_pm_whitespace=True), '123.456 +/- 0.789'),
+                (FormatOptions(unc_pm_whitespace=False), '123.456+/-0.789')
             ])
         ]
 
@@ -93,8 +94,8 @@ class TestFormatting(unittest.TestCase):
     def test_unicode_pm(self):
         cases_list = [
             ((123.456, 0.789), [
-                (Formatter(unicode_pm=True), '123.456 ± 0.789')
-                ])
+                (FormatOptions(unicode_pm=True), '123.456 ± 0.789')
+            ])
         ]
 
         self.run_val_unc_formatter_cases(cases_list)
@@ -102,8 +103,8 @@ class TestFormatting(unittest.TestCase):
     def test_superscript_exp(self):
         cases_list = [
             ((789, 0.01), [
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           superscript_exp=True), '(7.8900 +/- 0.0001)×10²')
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               superscript_exp=True), '(7.8900 +/- 0.0001)×10²')
             ])
         ]
 
@@ -112,29 +113,29 @@ class TestFormatting(unittest.TestCase):
     def test_latex(self):
         cases_list = [
             ((12345, 0.2), [
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-1,
-                           upper_separator=GroupingSeparator.UNDERSCORE,
-                           latex=True),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-1,
+                               upper_separator=GroupingSeparator.UNDERSCORE,
+                               latex=True),
                  r'\left(123\_450 \pm 2\right)\times 10^{-1}'),
 
                 # Latex mode takes precedence over unicode_pm
-                (Formatter(exp_mode=ExpMode.SCIENTIFIC,
-                           exp=-1,
-                           upper_separator=GroupingSeparator.UNDERSCORE,
-                           unicode_pm=True,
-                           latex=True),
+                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
+                               exp=-1,
+                               upper_separator=GroupingSeparator.UNDERSCORE,
+                               unicode_pm=True,
+                               latex=True),
                  r'\left(123\_450 \pm 2\right)\times 10^{-1}')
             ]),
             ((0.123_456_78, 0.000_002_55), [
-                (Formatter(lower_separator=GroupingSeparator.UNDERSCORE,
-                           percent=True,
-                           latex=True),
+                (FormatOptions(lower_separator=GroupingSeparator.UNDERSCORE,
+                               percent=True,
+                               latex=True),
                  r'\left(12.345\_678 \pm 0.000\_255\right)\%'),
-                (Formatter(lower_separator=GroupingSeparator.UNDERSCORE,
-                           percent=True,
-                           bracket_unc=True,
-                           latex=True),
+                (FormatOptions(lower_separator=GroupingSeparator.UNDERSCORE,
+                               percent=True,
+                               bracket_unc=True,
+                               latex=True),
                  r'\left(12.345\_678\left(255\right)\right)\%')
             ])
         ]
@@ -144,22 +145,22 @@ class TestFormatting(unittest.TestCase):
     def test_pdg(self):
         cases_list = [
             ((10, 0.0353), [
-                (Formatter(pdg_sig_figs=True), '10.000 +/- 0.035')
+                (FormatOptions(pdg_sig_figs=True), '10.000 +/- 0.035')
             ]),
             ((10, 0.0354), [
-                (Formatter(pdg_sig_figs=True), '10.000 +/- 0.035')
+                (FormatOptions(pdg_sig_figs=True), '10.000 +/- 0.035')
             ]),
             ((10, 0.0355), [
-                (Formatter(pdg_sig_figs=True), '10.00 +/- 0.04')
+                (FormatOptions(pdg_sig_figs=True), '10.00 +/- 0.04')
             ]),
             ((10, 0.0949), [
-                (Formatter(pdg_sig_figs=True), '10.00 +/- 0.09')
+                (FormatOptions(pdg_sig_figs=True), '10.00 +/- 0.09')
             ]),
             ((10, 0.0950), [
-                (Formatter(pdg_sig_figs=True), '10.00 +/- 0.10')
+                (FormatOptions(pdg_sig_figs=True), '10.00 +/- 0.10')
             ]),
             ((10, 0.0951), [
-                (Formatter(pdg_sig_figs=True), '10.00 +/- 0.10')
+                (FormatOptions(pdg_sig_figs=True), '10.00 +/- 0.10')
             ])
         ]
 

--- a/tests/test_val_unc_formatter.py
+++ b/tests/test_val_unc_formatter.py
@@ -8,7 +8,8 @@ ValUncFormatOptionsCases = list[tuple[tuple[float, float],
 
 
 class TestFormatting(unittest.TestCase):
-    def run_val_unc_formatter_cases(self, cases_list: ValUncFormatOptionsCases):
+    def run_val_unc_formatter_cases(self,
+                                    cases_list: ValUncFormatOptionsCases):
         for (val, unc), formats_list in cases_list:
             for format_options, expected_val_unc_str in formats_list:
                 formatter = Formatter(format_options)
@@ -103,8 +104,9 @@ class TestFormatting(unittest.TestCase):
     def test_superscript_exp(self):
         cases_list = [
             ((789, 0.01), [
-                (FormatOptions(exp_mode=ExpMode.SCIENTIFIC,
-                               superscript_exp=True), '(7.8900 +/- 0.0001)×10²')
+                (FormatOptions(
+                    exp_mode=ExpMode.SCIENTIFIC,
+                    superscript_exp=True), '(7.8900 +/- 0.0001)×10²')
             ])
         ]
 

--- a/tests/test_val_unc_formatter.py
+++ b/tests/test_val_unc_formatter.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sciform import Formatter, ExpMode, GroupingSeparator, FormatOptions
+from sciform import FormatOptions, Formatter, ExpMode, GroupingSeparator
 
 
 ValUncFormatOptionsCases = list[tuple[tuple[float, float],

--- a/tests/test_val_unc_fsml.py
+++ b/tests/test_val_unc_fsml.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sciform import SciNumUnc, GlobalDefaultsContext
+from sciform import SciNumUnc, GlobalDefaultsContext, FormatOptions
 
 
 ValUncFSMLCases = list[tuple[tuple[float, float],
@@ -247,7 +247,7 @@ class TestFormatting(unittest.TestCase):
                 ('e()', '(nan(nan))e+00')
             ])
         ]
-        with GlobalDefaultsContext(nan_inf_exp=True):
+        with GlobalDefaultsContext(FormatOptions(nan_inf_exp=True)):
             self.run_val_unc_fsml_cases(cases_list)
 
     def test_capitalization(self):
@@ -266,7 +266,7 @@ class TestFormatting(unittest.TestCase):
             ])
         ]
 
-        with GlobalDefaultsContext(nan_inf_exp=True):
+        with GlobalDefaultsContext(FormatOptions(nan_inf_exp=True)):
             self.run_val_unc_fsml_cases(cases_list)
 
     def test_rounding(self):


### PR DESCRIPTION
Somewhat large refactor so that users construct and pass `FormatOptions` for `Formatter` and global configuration. This adds a slight burden to user code, but allows for major simplification of `FormatOptions` handling on the backend. Specifically, it reduces the amount of code duplication necessary for handling the long list of available options.