### PR TITLE
bugfix/validate_options_on_render

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+0.26.2 (2023-08-18)
+-------------------
+
+* Fix a bug where illegal options combinations could be realized at
+  format time when certain global default objects were merged into
+  certain user specified options.
+  The bug is fixed by re-checking the options combinations after merging
+  in the global defaults but before formatting.
+
 0.26.1 (2023-08-18)
 -------------------
 

--- a/src/sciform/__init__.py
+++ b/src/sciform/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.26.1"
+__version__ = "0.26.2"
 
 from sciform.format_options import FormatOptions
 from sciform.formatter import Formatter

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -8,68 +8,6 @@ from sciform.modes import (FillMode, SignMode, GroupingSeparator,
                            AutoExpVal, AutoRound)
 
 
-def validate_options(options: Union['FormatOptions', 'RenderedFormatOptions']):
-    if options.round_mode is RoundMode.SIG_FIG:
-        if isinstance(options.ndigits, int):
-            if options.ndigits < 1:
-                raise ValueError(f'Precision must be >= 1 for sig fig '
-                                 f'rounding, not {options.ndigits}.')
-
-    if (options.pdg_sig_figs and options.ndigits is not None
-            and options.ndigits is not AutoRound):
-        # TODO: test this
-        raise ValueError(f'pdg_sig_figs=True can only be used with '
-                         f'ndigits=AutoRound, not ndigits={options.ndigits}.')
-
-    if options.exp_val is not AutoExpVal and options.exp_val is not None:
-        # TODO: Test these errors
-        if (options.exp_mode is ExpMode.FIXEDPOINT
-                or options.exp_mode is ExpMode.PERCENT):
-            if options.exp_val != 0:
-                raise ValueError(f'Exponent must must be 0, not '
-                                 f'exp_val={options.exp_val}, for fixed '
-                                 f'point and percent exponent modes.')
-        elif (options.exp_mode is ExpMode.ENGINEERING
-              or options.exp_mode is ExpMode.ENGINEERING_SHIFTED):
-            if options.exp_val % 3 != 0:
-                raise ValueError(f'Exponent must be a multiple of 3, not '
-                                 f'exp_val={options.exp_val}, for '
-                                 f'engineering exponent modes.')
-        elif options.exp_mode is ExpMode.BINARY_IEC:
-            if options.exp_val % 10 != 0:
-                raise ValueError(f'Exponent must be a multiple of 10, not '
-                                 f'exp_val={options.exp_val}, for binary IEC '
-                                 f'exponent mode.')
-
-    # TODO: Test all these separator errors
-    if options.upper_separator is not None:
-        if options.upper_separator not in get_args(UpperGroupingSeparators):
-            raise ValueError(f'upper_separator must be in '
-                             f'{get_args(UpperGroupingSeparators)}, not '
-                             f'{options.upper_separator}.')
-        if options.upper_separator is options.decimal_separator:
-            raise ValueError(f'upper_separator and decimal_separator '
-                             f'({options.upper_separator}) cannot be equal.')
-
-    if options.decimal_separator is not None:
-        if (options.decimal_separator
-                not in get_args(DecimalGroupingSeparators)):
-            raise ValueError(f'upper_separator must be in '
-                             f'{get_args(DecimalGroupingSeparators)}, not '
-                             f'{options.upper_separator}.')
-
-    if options.lower_separator is not None:
-        if options.lower_separator not in get_args(LowerGroupingSeparators):
-            raise ValueError(f'upper_separator must be in '
-                             f'{get_args(LowerGroupingSeparators)}, not '
-                             f'{options.upper_separator}.')
-
-    if options.prefix_exp is not None and options.parts_per_exp is not None:
-        if options.prefix_exp and options.parts_per_exp:
-            raise ValueError('Only one of prefix exponent and parts-per '
-                             'exponent modes may be selected.')
-
-
 @dataclass(frozen=True)
 class RenderedFormatOptions:
     exp_mode: ExpMode
@@ -325,6 +263,65 @@ class FormatOptions:
                              f'with default options.') from e
 
         return rendered_format_options
+
+
+def validate_options(options: Union[FormatOptions, RenderedFormatOptions]):
+    if options.round_mode is RoundMode.SIG_FIG:
+        if isinstance(options.ndigits, int):
+            if options.ndigits < 1:
+                raise ValueError(f'Precision must be >= 1 for sig fig '
+                                 f'rounding, not {options.ndigits}.')
+
+    if (options.pdg_sig_figs and options.ndigits is not None
+            and options.ndigits is not AutoRound):
+        raise ValueError(f'pdg_sig_figs=True can only be used with '
+                         f'ndigits=AutoRound, not ndigits={options.ndigits}.')
+
+    if options.exp_val is not AutoExpVal and options.exp_val is not None:
+        if (options.exp_mode is ExpMode.FIXEDPOINT
+                or options.exp_mode is ExpMode.PERCENT):
+            if options.exp_val != 0:
+                raise ValueError(f'Exponent must must be 0, not '
+                                 f'exp_val={options.exp_val}, for fixed '
+                                 f'point and percent exponent modes.')
+        elif (options.exp_mode is ExpMode.ENGINEERING
+              or options.exp_mode is ExpMode.ENGINEERING_SHIFTED):
+            if options.exp_val % 3 != 0:
+                raise ValueError(f'Exponent must be a multiple of 3, not '
+                                 f'exp_val={options.exp_val}, for '
+                                 f'engineering exponent modes.')
+        elif options.exp_mode is ExpMode.BINARY_IEC:
+            if options.exp_val % 10 != 0:
+                raise ValueError(f'Exponent must be a multiple of 10, not '
+                                 f'exp_val={options.exp_val}, for binary IEC '
+                                 f'exponent mode.')
+
+    if options.upper_separator is not None:
+        if options.upper_separator not in get_args(UpperGroupingSeparators):
+            raise ValueError(f'upper_separator must be in '
+                             f'{get_args(UpperGroupingSeparators)}, not '
+                             f'{options.upper_separator}.')
+        if options.upper_separator is options.decimal_separator:
+            raise ValueError(f'upper_separator and decimal_separator '
+                             f'({options.upper_separator}) cannot be equal.')
+
+    if options.decimal_separator is not None:
+        if (options.decimal_separator
+                not in get_args(DecimalGroupingSeparators)):
+            raise ValueError(f'upper_separator must be in '
+                             f'{get_args(DecimalGroupingSeparators)}, not '
+                             f'{options.upper_separator}.')
+
+    if options.lower_separator is not None:
+        if options.lower_separator not in get_args(LowerGroupingSeparators):
+            raise ValueError(f'upper_separator must be in '
+                             f'{get_args(LowerGroupingSeparators)}, not '
+                             f'{options.upper_separator}.')
+
+    if options.prefix_exp is not None and options.parts_per_exp is not None:
+        if options.prefix_exp and options.parts_per_exp:
+            raise ValueError('Only one of prefix exponent and parts-per '
+                             'exponent modes may be selected.')
 
 
 PKG_DEFAULT_OPTIONS = RenderedFormatOptions(

--- a/src/sciform/format_options.py
+++ b/src/sciform/format_options.py
@@ -8,6 +8,68 @@ from sciform.modes import (FillMode, SignMode, GroupingSeparator,
                            AutoExpVal, AutoRound)
 
 
+def validate_options(options: Union['FormatOptions', 'RenderedFormatOptions']):
+    if options.round_mode is RoundMode.SIG_FIG:
+        if isinstance(options.ndigits, int):
+            if options.ndigits < 1:
+                raise ValueError(f'Precision must be >= 1 for sig fig '
+                                 f'rounding, not {options.ndigits}.')
+
+    if (options.pdg_sig_figs and options.ndigits is not None
+            and options.ndigits is not AutoRound):
+        # TODO: test this
+        raise ValueError(f'pdg_sig_figs=True can only be used with '
+                         f'ndigits=AutoRound, not ndigits={options.ndigits}.')
+
+    if options.exp_val is not AutoExpVal and options.exp_val is not None:
+        # TODO: Test these errors
+        if (options.exp_mode is ExpMode.FIXEDPOINT
+                or options.exp_mode is ExpMode.PERCENT):
+            if options.exp_val != 0:
+                raise ValueError(f'Exponent must must be 0, not '
+                                 f'exp_val={options.exp_val}, for fixed '
+                                 f'point and percent exponent modes.')
+        elif (options.exp_mode is ExpMode.ENGINEERING
+              or options.exp_mode is ExpMode.ENGINEERING_SHIFTED):
+            if options.exp_val % 3 != 0:
+                raise ValueError(f'Exponent must be a multiple of 3, not '
+                                 f'exp_val={options.exp_val}, for '
+                                 f'engineering exponent modes.')
+        elif options.exp_mode is ExpMode.BINARY_IEC:
+            if options.exp_val % 10 != 0:
+                raise ValueError(f'Exponent must be a multiple of 10, not '
+                                 f'exp_val={options.exp_val}, for binary IEC '
+                                 f'exponent mode.')
+
+    # TODO: Test all these separator errors
+    if options.upper_separator is not None:
+        if options.upper_separator not in get_args(UpperGroupingSeparators):
+            raise ValueError(f'upper_separator must be in '
+                             f'{get_args(UpperGroupingSeparators)}, not '
+                             f'{options.upper_separator}.')
+        if options.upper_separator is options.decimal_separator:
+            raise ValueError(f'upper_separator and decimal_separator '
+                             f'({options.upper_separator}) cannot be equal.')
+
+    if options.decimal_separator is not None:
+        if (options.decimal_separator
+                not in get_args(DecimalGroupingSeparators)):
+            raise ValueError(f'upper_separator must be in '
+                             f'{get_args(DecimalGroupingSeparators)}, not '
+                             f'{options.upper_separator}.')
+
+    if options.lower_separator is not None:
+        if options.lower_separator not in get_args(LowerGroupingSeparators):
+            raise ValueError(f'upper_separator must be in '
+                             f'{get_args(LowerGroupingSeparators)}, not '
+                             f'{options.upper_separator}.')
+
+    if options.prefix_exp is not None and options.parts_per_exp is not None:
+        if options.prefix_exp and options.parts_per_exp:
+            raise ValueError('Only one of prefix exponent and parts-per '
+                             'exponent modes may be selected.')
+
+
 @dataclass(frozen=True)
 class RenderedFormatOptions:
     exp_mode: ExpMode
@@ -35,6 +97,9 @@ class RenderedFormatOptions:
     bracket_unc_remove_seps: bool
     unicode_pm: bool
     unc_pm_whitespace: bool
+
+    def __post_init__(self):
+        validate_options(self)
 
 
 def _merge_dicts(left: dict, right: dict) -> dict:
@@ -203,66 +268,6 @@ class FormatOptions:
 
     def __post_init__(self, add_c_prefix, add_small_si_prefixes,
                       add_ppth_form):
-        if self.round_mode is RoundMode.SIG_FIG:
-            if isinstance(self.ndigits, int):
-                if self.ndigits < 1:
-                    raise ValueError(f'Precision must be >= 1 for sig fig '
-                                     f'rounding, not {self.ndigits}.')
-
-        if (self.pdg_sig_figs and self.ndigits is not None
-                and self.ndigits is not AutoRound):
-            # TODO: test this
-            raise ValueError(f'pdg_sig_figs=True can only be used with '
-                             f'ndigits=AutoRound, not ndigits={self.ndigits}.')
-
-        if self.exp_val is not AutoExpVal and self.exp_val is not None:
-            # TODO: Test these errors
-            if (self.exp_mode is ExpMode.FIXEDPOINT
-                    or self.exp_mode is ExpMode.PERCENT):
-                if self.exp_val != 0:
-                    raise ValueError(f'Exponent must must be 0, not '
-                                     f'exp_val={self.exp_val}, for fixed '
-                                     f'point and percent exponent modes.')
-            elif (self.exp_mode is ExpMode.ENGINEERING
-                  or self.exp_mode is ExpMode.ENGINEERING_SHIFTED):
-                if self.exp_val % 3 != 0:
-                    raise ValueError(f'Exponent must be a multiple of 3, not '
-                                     f'exp_val={self.exp_val}, for '
-                                     f'engineering exponent modes.')
-            elif self.exp_mode is ExpMode.BINARY_IEC:
-                if self.exp_val % 10 != 0:
-                    raise ValueError(f'Exponent must be a multiple of 10, not '
-                                     f'exp_val={self.exp_val}, for binary IEC '
-                                     f'exponent mode.')
-
-        # TODO: Test all these separator errors
-        if self.upper_separator is not None:
-            if self.upper_separator not in get_args(UpperGroupingSeparators):
-                raise ValueError(f'upper_separator must be in '
-                                 f'{get_args(UpperGroupingSeparators)}, not '
-                                 f'{self.upper_separator}.')
-            if self.upper_separator is self.decimal_separator:
-                raise ValueError(f'upper_separator and decimal_separator '
-                                 f'({self.upper_separator}) cannot be equal.')
-
-        if self.decimal_separator is not None:
-            if (self.decimal_separator
-                    not in get_args(DecimalGroupingSeparators)):
-                raise ValueError(f'upper_separator must be in '
-                                 f'{get_args(DecimalGroupingSeparators)}, not '
-                                 f'{self.upper_separator}.')
-
-        if self.lower_separator is not None:
-            if self.lower_separator not in get_args(LowerGroupingSeparators):
-                raise ValueError(f'upper_separator must be in '
-                                 f'{get_args(LowerGroupingSeparators)}, not '
-                                 f'{self.upper_separator}.')
-
-        if self.prefix_exp is not None and self.parts_per_exp is not None:
-            if self.prefix_exp and self.parts_per_exp:
-                raise ValueError('Only one of prefix exponent and parts-per '
-                                 'exponent modes may be selected.')
-
         # TODO: Test that things do and don't get added appropriately
         if add_c_prefix:
             if self.extra_si_prefixes is None:
@@ -288,6 +293,8 @@ class FormatOptions:
             if -3 not in self.extra_parts_per_forms:
                 self.extra_parts_per_forms[-3] = 'ppth'
 
+        validate_options(self)
+
     def merge(self, other: 'FormatOptions') -> 'FormatOptions':
         """
         Generate a new :class:`FormatOptions` instance from the current
@@ -309,9 +316,15 @@ class FormatOptions:
                ) -> RenderedFormatOptions:
         if defaults is None:
             defaults = get_global_defaults()
-        return RenderedFormatOptions(
-            **_merge_dicts(asdict(defaults), asdict(self))
-        )
+        try:
+            rendered_format_options = RenderedFormatOptions(
+                **_merge_dicts(asdict(defaults), asdict(self))
+            )
+        except ValueError as e:
+            raise ValueError(f'Invalid format options resuling from merging '
+                             f'with default options.') from e
+
+        return rendered_format_options
 
 
 PKG_DEFAULT_OPTIONS = RenderedFormatOptions(

--- a/tests/test_invalid_options.py
+++ b/tests/test_invalid_options.py
@@ -91,8 +91,18 @@ class TestInvalidOptions(unittest.TestCase):
             lower_separator=GroupingSeparator.POINT
         )
 
-    @unittest.expectedFailure
     def test_upper_separator_point_default_merge(self):
+        """
+        This test raises a ValueError because the upper_separator is
+        requested to be POINT. But the package defaults set
+        decimal_separator to also be POINT. So when the FormatOptions
+        is rendered into RenderedFormatOptions, at format time, the
+        resulting RenderedFormatOptions have both
+        upper_separator=GroupingSeparator.POINT
+        and
+        decimal_separator=GroupingSeparator.POINT
+        This options combination is not allowed.
+        """
         sform = Formatter(
             FormatOptions(upper_separator=GroupingSeparator.POINT))
         self.assertRaises(ValueError, sform, 42)


### PR DESCRIPTION
Fixes #31

 break out validate options and apply it to `FormatOptions` on instantiation and `RenderedFormatOptions` also on instantiation. The latter will trigger when rendering `FormatOptions`.