### PR TITLE
Fix/zero unc failures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,10 +9,10 @@ Fixed
 ^^^^^
 
 * Fixed bugs where values were incorrectly rounded when
-  `pdg_sig_figs` was used with 0 or non-finite uncertainty.
+  ``pdg_sig_figs`` was used with 0 or non-finite uncertainty.
   Previously, if the value was positive it would possibly be rounded
   incorrectly.
-  Now the value will be rounded under the same rules as `AutoDigits`.
+  Now the value will be rounded under the same rules as ``AutoDigits``.
   Previously, if the value was zero or negative a spurious exception
   would be raised.
   Now the value/uncertainty pair is formatted correctly without raising

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 Unreleased
 ----------
 
+Fixed
+^^^^^
+
+* Fixed bugs where values were incorrectly rounded when
+  `pdg_sig_figs` was used with 0 uncertainty.
+  Previously, if the value was positive it would possibly be rounded
+  incorrectly.
+  Now the value will be rounded under the same rules as `AutoDigits`.
+  Previously, if the value was zero or negative a spurious exception
+  would be raised.
+  Now the value/uncertainty pair is formatted correctly without an
+  exceptions.
+
 Changed
 ^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,14 +9,14 @@ Fixed
 ^^^^^
 
 * Fixed bugs where values were incorrectly rounded when
-  `pdg_sig_figs` was used with 0 uncertainty.
+  `pdg_sig_figs` was used with 0 or non-finite uncertainty.
   Previously, if the value was positive it would possibly be rounded
   incorrectly.
   Now the value will be rounded under the same rules as `AutoDigits`.
   Previously, if the value was zero or negative a spurious exception
   would be raised.
-  Now the value/uncertainty pair is formatted correctly without an
-  exceptions.
+  Now the value/uncertainty pair is formatted correctly without raising
+  and exception.
 
 Changed
 ^^^^^^^

--- a/src/sciform/formatting.py
+++ b/src/sciform/formatting.py
@@ -161,8 +161,8 @@ def format_val_unc(val: Decimal, unc: Decimal,
     else:
         round_driver = val
         '''
-        Don't use pdg sig figs unless the uncertainty drivers the number of sig
-        figs.
+        Don't use pdg sig figs if the uncertainty doesn't drive the number of 
+        sig figs.
         '''
         use_pdg_sig_figs = False
 

--- a/src/sciform/formatting.py
+++ b/src/sciform/formatting.py
@@ -157,11 +157,17 @@ def format_val_unc(val: Decimal, unc: Decimal,
     # Find the digit place to round to
     if unc.is_finite() and unc != 0:
         round_driver = unc
+        use_pdg_sig_figs = options.pdg_sig_figs
     else:
         round_driver = val
+        '''
+        Don't use pdg sig figs unless the uncertainty drivers the number of sig
+        figs.
+        '''
+        use_pdg_sig_figs = False
 
     round_digit = get_round_digit(round_driver, RoundMode.SIG_FIG,
-                                  options.ndigits, options.pdg_sig_figs)
+                                  options.ndigits, use_pdg_sig_figs)
     if unc.is_finite():
         unc_rounded = round(unc, -round_digit)
     else:
@@ -173,14 +179,14 @@ def format_val_unc(val: Decimal, unc: Decimal,
     if round_driver.is_finite():
         round_driver = round(round_driver, -round_digit)
 
-    if not options.pdg_sig_figs:
+    if not use_pdg_sig_figs:
         '''
         Re-round the rounded values in case the first rounding changed the most
         significant digit place. When using pdg_sig_figs this case is handled
         directly in the first call to get_round_digit.
         '''
         round_digit = get_round_digit(round_driver, RoundMode.SIG_FIG,
-                                      options.ndigits, options.pdg_sig_figs)
+                                      options.ndigits, use_pdg_sig_figs)
         if unc_rounded.is_finite():
             unc_rounded = round(unc_rounded, -round_digit)
         if val_rounded.is_finite():

--- a/tests/test_val_unc_formatter.py
+++ b/tests/test_val_unc_formatter.py
@@ -215,6 +215,18 @@ class TestFormatting(unittest.TestCase):
                 (FormatOptions(exp_mode=ExpMode.ENGINEERING,
                                exp_format=ExpFormat.PREFIX,
                                pdg_sig_figs=True), '(3.1416 +/- 0.0016) M')
+            ]),
+            ((123, 0), [
+                (FormatOptions(pdg_sig_figs=True), '123 +/- 0')
+            ]),
+            ((-123, 0), [
+                (FormatOptions(pdg_sig_figs=True), '-123 +/- 0')
+            ]),
+            ((-1, 0), [
+                (FormatOptions(pdg_sig_figs=True), '-1 +/- 0')
+            ]),
+            ((0, 0), [
+                (FormatOptions(pdg_sig_figs=True), '0 +/- 0')
             ])
         ]
 

--- a/tests/test_val_unc_formatter.py
+++ b/tests/test_val_unc_formatter.py
@@ -215,22 +215,35 @@ class TestFormatting(unittest.TestCase):
                 (FormatOptions(exp_mode=ExpMode.ENGINEERING,
                                exp_format=ExpFormat.PREFIX,
                                pdg_sig_figs=True), '(3.1416 +/- 0.0016) M')
-            ]),
+            ])
+        ]
+
+        self.run_val_unc_formatter_cases(cases_list)
+
+    def test_pdg_invalid_unc(self):
+        cases_list = [
             ((123, 0), [
                 (FormatOptions(pdg_sig_figs=True), '123 +/- 0')
             ]),
             ((-123, 0), [
                 (FormatOptions(pdg_sig_figs=True), '-123 +/- 0')
             ]),
-            ((-1, 0), [
-                (FormatOptions(pdg_sig_figs=True), '-1 +/- 0')
-            ]),
             ((0, 0), [
                 (FormatOptions(pdg_sig_figs=True), '0 +/- 0')
-            ])
+            ]),
+            ((123, float('nan')), [
+                (FormatOptions(pdg_sig_figs=True), '123 +/- nan')
+            ]),
+            ((-123, float('nan')), [
+                (FormatOptions(pdg_sig_figs=True), '-123 +/- nan')
+            ]),
+            ((0, float('nan')), [
+                (FormatOptions(pdg_sig_figs=True), '0 +/- nan')
+            ]),
         ]
 
         self.run_val_unc_formatter_cases(cases_list)
+
 
     def test_binary_not_implemented(self):
         sform = Formatter(FormatOptions(exp_mode=ExpMode.BINARY))


### PR DESCRIPTION
Fixes https://github.com/jagerber48/sciform/issues/65.

The uncertainty = 0 branch was not handled appropriately with `pdg_sig_figs`. Now the uncertainty = 0 branch is handled the same as `AutoDigits`.