### PR TITLE
Feature/resolve ndigits pdg sig figs 73

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
   For value/uncertainty formatting ``ndigits`` is ignored if
   ``pdg_sig_figs=True``.
   The behavior for ``pdg_sig_figs=False`` is unchanged.
+  [`#73 <https://github.com/jagerber48/sciform/issues/73>`_]
 
 ----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,18 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 Unreleased
 ----------
 
-* There are no unreleased changes.
+Added
+^^^^^
+
+* Previously it was impossible to configure ``pdg_sig_figs=True``
+  together with ``ndigits!=AutoDigits``.
+  This combinations resulted in an exception.
+  Now behavior has been defined and implemented for this combination.
+  For single value formatting the value of ``pdg_sig_figs`` is always
+  ignored.
+  For value/uncertainty formatting ``ndigits`` is ignored if
+  ``pdg_sig_figs=True``.
+  The behavior for ``pdg_sig_figs=False`` is unchanged.
 
 ----
 

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -397,15 +397,7 @@ For value/uncertainty formatting, if ``ndigits=AutoDigits`` and
 ``pdg_sig_figs=False``, then the rounding strategy described in the
 previous paragraph is used to round the uncertainty and the value is
 rounded to the same decimal place as the uncertainty.
-If ``ndigits=AutoDigits`` and ``pdg_sig_figs=True``, then the
-uncertainty will be rounded according to the Particle Data Group
-rounding algorithm and the value will rounded to the same decimal place
-as the uncertainty.
 See :ref:`pdg_sig_figs` for more details.
-
-If ``ndigits`` is specified (i.e. not ``None``) but
-``ndigits!=AutoDigits`` and ``pdg_sig_figs=True`` then ``ValueError``
-is raised.
 
 .. _separators:
 
@@ -660,12 +652,11 @@ The algorithm is as follows.
 
 :mod:`sciform` provides the ability to use this algorithm when
 formatting value/uncertainty pairs by using significant figure rounding
-mode with :class:`AutoDigits` precision and the ``pdg_sig_figs`` flag.
+mode and the ``pdg_sig_figs`` flag.
 
 >>> from sciform import AutoDigits
 >>> sform = Formatter(
 ...     round_mode="sig_fig",
-...     ndigits=AutoDigits,
 ...     pdg_sig_figs=True,
 ... )
 >>> print(sform(1, 0.0123))
@@ -675,9 +666,10 @@ mode with :class:`AutoDigits` precision and the ``pdg_sig_figs`` flag.
 >>> print(sform(1, 0.0997))
 1.00 ± 0.10
 
-If ``ndigits`` is specified (i.e. not ``None``) but
-``ndigits!=AutoDigits`` with ``pdg_sig_figs=True`` then ``ValueError``
-is raised.
+If ``pdg_sig_figs=True`` then ``ndigits`` is ignored for
+value/uncertainty formatting.
+``pdg_sig_figs`` is always ignored in favor of ``ndigits`` for single
+value formatting.
 
 .. _paren_uncertainty:
 

--- a/src/sciform/format_utils.py
+++ b/src/sciform/format_utils.py
@@ -318,11 +318,10 @@ def get_round_digit(
 ) -> int:
     """Get the digit place to which to round."""
     if round_mode is RoundMode.SIG_FIG:
-        if ndigits is AutoDigits:
-            if pdg_sig_figs:
-                round_digit = get_pdg_round_digit(num)
-            else:
-                round_digit = get_bottom_digit(num)
+        if pdg_sig_figs:
+            round_digit = get_pdg_round_digit(num)
+        elif ndigits is AutoDigits:
+            round_digit = get_bottom_digit(num)
         else:
             round_digit = get_top_digit(num) - (ndigits - 1)
     elif round_mode is RoundMode.DEC_PLACE:

--- a/src/sciform/formatter.py
+++ b/src/sciform/formatter.py
@@ -12,8 +12,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from sciform import modes
     from sciform.format_utils import Number
 
-# TODO: Support SciNum input to formatter?
-
 
 class Formatter:
     """
@@ -250,5 +248,3 @@ class Formatter:
                 rendered_options,
             )
         return output
-
-    # TODO: print_options and print_resolved_options?

--- a/src/sciform/formatter.py
+++ b/src/sciform/formatter.py
@@ -88,8 +88,6 @@ class Formatter:
           but must be different from ``decimal_separator``
         * ``decimal_separator`` may be any of ``['.', ',']``
         * ``lower_separator`` may be any of ``['', ' ', '_']``
-        * if ``pdg_sig_figs=True`` then ``ndigits=None`` or
-          ``ndigits=AutoDigits``.
 
         :param exp_mode: Specify the formatting mode.
         :type exp_mode: ``Literal['fixed_point', 'percent',
@@ -169,7 +167,7 @@ class Formatter:
         :param pdg_sig_figs: Flag indicating whether the
           particle-data-group conventions should be used to
           automatically determine the number of significant figures to
-          use for uncertainty.
+          use for uncertainty. Ignored for single value formatting.
         :type pdg_sig_figs: ``bool | None``
         :param left_pad_matching: Flag indicating if the value or
           uncertainty should be left padded to ensure they are both left

--- a/src/sciform/global_configuration.py
+++ b/src/sciform/global_configuration.py
@@ -93,11 +93,6 @@ def reset_global_defaults() -> None:
     global_options.GLOBAL_DEFAULT_OPTIONS = global_options.PKG_DEFAULT_OPTIONS
 
 
-# TODO: Need to clean up the semantics on add_c_prefix in both Formatter
-#  and these global configuration options. Does it truly just add the
-#  value to the dict if it's not present? Or does the whole dict get
-#  overwritten? Are these helpers even needed? They're redundant with
-#  set_global_defaults.
 def global_add_c_prefix() -> None:
     """
     Include ``c`` as a prefix for the exponent value -2.

--- a/src/sciform/modes.py
+++ b/src/sciform/modes.py
@@ -50,9 +50,6 @@ class AutoDigits(metaclass=SentinelMeta):
     """
 
 
-# TODO: UserName and Name objects should be renamed to Name and NameEnum
-
-
 UserFillChar = Literal[" ", "0"]
 
 

--- a/src/sciform/user_options.py
+++ b/src/sciform/user_options.py
@@ -63,7 +63,6 @@ class UserOptions:
         add_ppth_form: bool,
     ) -> None:
         """Populate extra prefix translations from user input flags."""
-        # TODO: Test that things do and don't get added appropriately
         if add_c_prefix:
             if self.extra_si_prefixes is None:
                 super().__setattr__("extra_si_prefixes", {})

--- a/src/sciform/user_options.py
+++ b/src/sciform/user_options.py
@@ -98,17 +98,6 @@ class UserOptions:
             msg = f"ndigits must be >= 1 for sig fig rounding, not {options.ndigits}."
             raise ValueError(msg)
 
-        if (
-            options.pdg_sig_figs
-            and options.ndigits is not None
-            and options.ndigits is not modes.AutoDigits
-        ):
-            msg = (
-                f"pdg_sig_figs=True can only be used with ndigits=AutoDigits, not "
-                f"ndigits={options.ndigits}."
-            )
-            raise ValueError(msg)
-
         if options.exp_val is not modes.AutoExpVal and options.exp_val is not None:
             if options.exp_mode in ["fixed_point", "percent"] and options.exp_val != 0:
                 msg = (

--- a/tests/test_float_formatter.py
+++ b/tests/test_float_formatter.py
@@ -255,3 +255,30 @@ class TestFormatting(unittest.TestCase):
     def test_dec_place_auto_round(self):
         sform = Formatter(round_mode="dec_place", ndigits=AutoDigits)
         self.assertEqual(sform(123.456), "123.456")
+
+    def test_pdg_sig_figs(self):
+        cases_list = [
+            (
+                6789,
+                [
+                    (
+                        Formatter(pdg_sig_figs=True, ndigits=AutoDigits),
+                        "6789",
+                    ),
+                    (
+                        Formatter(pdg_sig_figs=True, ndigits=5),
+                        "6789.0",
+                    ),
+                    (
+                        Formatter(pdg_sig_figs=False, ndigits=AutoDigits),
+                        "6789",
+                    ),
+                    (
+                        Formatter(pdg_sig_figs=False, ndigits=5),
+                        "6789.0",
+                    ),
+                ],
+            ),
+        ]
+
+        self.run_float_formatter_cases(cases_list)

--- a/tests/test_invalid_options.py
+++ b/tests/test_invalid_options.py
@@ -26,14 +26,6 @@ class TestInvalidOptions(unittest.TestCase):
             ndigits=0,
         )
 
-    def test_pdg_sig_figs_ndigits(self):
-        self.assertRaises(
-            ValueError,
-            Formatter,
-            pdg_sig_figs=True,
-            ndigits=3,
-        )
-
     def test_fixed_point(self):
         self.assertRaises(
             ValueError,

--- a/tests/test_val_unc_formatter.py
+++ b/tests/test_val_unc_formatter.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sciform import Formatter
+from sciform import AutoDigits, Formatter
 
 ValUncFormatterCases = list[tuple[tuple[float, float], list[tuple[Formatter, str]]]]
 
@@ -501,6 +501,33 @@ class TestFormatting(unittest.TestCase):
 
     def test_pdg_ndigits_error(self):
         self.assertRaises(ValueError, Formatter, pdg_sig_figs=True, ndigits=0)
+
+    def test_pdg_sig_figs(self):
+        cases_list = [
+            (
+                (7, 0.1234),
+                [
+                    (
+                        Formatter(pdg_sig_figs=True, ndigits=AutoDigits),
+                        "7.00 ± 0.12",
+                    ),
+                    (
+                        Formatter(pdg_sig_figs=True, ndigits=5),
+                        "7.00 ± 0.12",
+                    ),
+                    (
+                        Formatter(pdg_sig_figs=False, ndigits=AutoDigits),
+                        "7.0000 ± 0.1234",
+                    ),
+                    (
+                        Formatter(pdg_sig_figs=False, ndigits=5),
+                        "7.00000 ± 0.12340",
+                    ),
+                ],
+            ),
+        ]
+
+        self.run_val_unc_formatter_cases(cases_list)
 
     def test_dec_place_warn(self):
         sform = Formatter(round_mode="dec_place")

--- a/tests/test_val_unc_formatter.py
+++ b/tests/test_val_unc_formatter.py
@@ -499,9 +499,6 @@ class TestFormatting(unittest.TestCase):
         sform = Formatter(exp_mode="binary")
         self.assertEqual(sform(1024, 32), "(1.00000 ± 0.03125)b+10")
 
-    def test_pdg_ndigits_error(self):
-        self.assertRaises(ValueError, Formatter, pdg_sig_figs=True, ndigits=0)
-
     def test_pdg_sig_figs(self):
         cases_list = [
             (


### PR DESCRIPTION
Address https://github.com/jagerber48/sciform/issues/73 by defining and implementing functionality when `pdg_sig_figs=True` but `ndigits!=AutoDigits`. Currently for these cases an exception is raised. This PR allows `ndigits!=AutoDigits` even when `pdg_sig_figs=True`. For value formatting the value of `pdg_sig_figs` will always be ignored. For value/uncertainty formatting `pdg_sig_figs=True` will always take precedence over `ndigits`.