### PR TITLE
Feature/clarify extra prefixes behavior 97

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,17 @@ Added
   The behavior for ``pdg_sig_figs=False`` is unchanged.
   [`#73 <https://github.com/jagerber48/sciform/issues/73>`_]
 
+Removed
+^^^^^^^
+
+* **[BREAKING]** Removed ``global_add_c_prefix``,
+  ``global_add_small_si_prefixes``, ``global_add_ppth_form``,
+  ``global_reset_si_prefixes``, ``global_reset_iec_prefixes``, and
+  ``global_reset_parts_per_forms``.
+  These options are redundant with ``set_global_defaults`` and
+  ``GlobalDefaultsContext`` and make the extra translations dictionaries
+  more confusing to understand.
+
 ----
 
 0.31.1 (2024-01-06)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Removed
   These options are redundant with ``set_global_defaults`` and
   ``GlobalDefaultsContext`` and make the extra translations dictionaries
   more confusing to understand.
+  [`#97 <https://github.com/jagerber48/sciform/issues/97>`_]
 
 ----
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -32,15 +32,3 @@ Global Configuration
 .. autofunction:: reset_global_defaults()
 
 .. autoclass:: GlobalDefaultsContext()
-
-.. autofunction:: global_add_c_prefix()
-
-.. autofunction:: global_add_small_si_prefixes()
-
-.. autofunction:: global_add_ppth_form()
-
-.. autofunction:: global_reset_si_prefixes()
-
-.. autofunction:: global_reset_iec_prefixes()
-
-.. autofunction:: global_reset_parts_per_forms()

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -287,6 +287,25 @@ but it is one that the author has found useful.
 >>> print(sform(12.3e-3))
 12.3 ppth
 
+Note that the helper flags will not overwrite value/string pairs already
+specified in the extra translations dictionary:
+
+>>> sform = Formatter(
+...     exp_mode="scientific",
+...     exp_format="prefix",
+...     add_c_prefix=True,
+... )
+>>> print(sform(0.012))
+1.2 c
+>>> sform = Formatter(
+...     exp_mode="scientific",
+...     exp_format="prefix",
+...     extra_si_prefixes={-2: 'zzz'},
+...     add_c_prefix=True,
+... )
+>>> print(sform(0.012))
+1.2 zzz
+
 .. _rounding:
 
 Rounding

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -306,6 +306,14 @@ specified in the extra translations dictionary:
 >>> print(sform(0.012))
 1.2 zzz
 
+Note that if any values are set for e.g. ``extra_si_prefixes`` either
+directly or through a helper flag like ``add_small_si_prefixes`` then,
+like all other options, no settings from the global options will be
+utilized.
+However, if all of the settings are left unpopulated then they will be
+populated at format time from the global options.
+Likewise for ``extra_iec_prefixes`` and ``extra_parts_per_forms``.
+
 .. _rounding:
 
 Rounding

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -310,8 +310,9 @@ Note that if any values are set for e.g. ``extra_si_prefixes`` either
 directly or through a helper flag like ``add_small_si_prefixes`` then,
 like all other options, no settings from the global options will be
 utilized.
-However, if all of the settings are left unpopulated then they will be
-populated at format time from the global options.
+However, if all of the settings are left unpopulated then, like all
+other options, they will be populated at format time from the global
+options.
 Likewise for ``extra_iec_prefixes`` and ``extra_parts_per_forms``.
 
 .. _rounding:

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -306,14 +306,35 @@ specified in the extra translations dictionary:
 >>> print(sform(0.012))
 1.2 zzz
 
-Note that if any values are set for e.g. ``extra_si_prefixes`` either
-directly or through a helper flag like ``add_small_si_prefixes`` then,
-like all other options, no settings from the global options will be
-utilized.
-However, if all of the settings are left unpopulated then, like all
-other options, they will be populated at format time from the global
-options.
-Likewise for ``extra_iec_prefixes`` and ``extra_parts_per_forms``.
+Note that there is never *merging* of local and global extra
+translations.
+If any local extra translation settings are configured directly with
+e.g. ``extra_si_prefixes`` or with a helper like
+``add_small_si_prefixes`` then no global extra translations will be
+used.
+
+>>> from sciform import GlobalDefaultsContext
+>>> sform = Formatter(
+...     exp_mode="scientific",
+...     exp_format="prefix",
+...     extra_si_prefixes={-4: "zzz"},
+... )
+>>> with GlobalDefaultsContext(add_c_prefix=True):
+...     print(sform(0.012))
+1.2e-02
+>>> sform = Formatter(
+...     exp_mode="scientific",
+...     exp_format="prefix",
+...     add_c_prefix=True,
+... )
+>>> with GlobalDefaultsContext(extra_si_prefixes={1: 'zzz'}):
+...     print(sform(12.4))
+1.24e+01
+
+If all local extra translation settings are left unset then all global
+extra translation settings will be populated at format time.
+This behavior is the same as the behavior for all other options.
+
 
 .. _rounding:
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -190,25 +190,6 @@ using :func:`reset_global_defaults`.
 >>> from sciform import reset_global_defaults
 >>> reset_global_defaults()
 
-There are also helper functions for managing supported
-:ref:`extra_translations`:
-
-* :func:`global_add_c_prefix()` add ``{-2: 'c'}`` to the
-  ``extra_si_prefixes`` dictionary if there is not already a prefix
-  assigned to ``-2``.
-* :func:`global_add_small_si_prefixes()` adds any of ``{-2: 'c',
-  -1: 'd', +1: 'da', +2: 'h'}`` to the ``extra_si_prefixes`` that do not
-  already have assigned prefixes.
-* :func:`global_add_ppth_form()` add ``{-3: 'ppth'}`` to the
-  ``extra_parts_per_forms`` dictionary if there is not already a prefix
-  assigned to ``-3``.
-* :func:`global_reset_si_prefixes()` resets ``extra_si_prefixes`` to be
-  empty.
-* :func:`global_reset_iec_prefixes()` resets ``extra_iec_prefixes`` to
-  be empty.
-* :func:`global_reset_parts_per_forms()` resets
-  ``extra_parts_per_forms`` to be empty.
-
 The global default settings can be temporarily modified using the
 :class:`GlobalDefaultsContext` context manager.
 The context manager is configured using the same options as

--- a/src/sciform/__init__.py
+++ b/src/sciform/__init__.py
@@ -3,12 +3,6 @@
 from sciform.formatter import Formatter
 from sciform.global_configuration import (
     GlobalDefaultsContext,
-    global_add_c_prefix,
-    global_add_ppth_form,
-    global_add_small_si_prefixes,
-    global_reset_iec_prefixes,
-    global_reset_parts_per_forms,
-    global_reset_si_prefixes,
     print_global_defaults,
     reset_global_defaults,
     set_global_defaults,
@@ -19,12 +13,6 @@ from sciform.scinum import SciNum
 __all__ = [
     "Formatter",
     "GlobalDefaultsContext",
-    "global_add_c_prefix",
-    "global_add_ppth_form",
-    "global_add_small_si_prefixes",
-    "global_reset_iec_prefixes",
-    "global_reset_parts_per_forms",
-    "global_reset_si_prefixes",
     "print_global_defaults",
     "reset_global_defaults",
     "set_global_defaults",

--- a/src/sciform/global_configuration.py
+++ b/src/sciform/global_configuration.py
@@ -93,56 +93,6 @@ def reset_global_defaults() -> None:
     global_options.GLOBAL_DEFAULT_OPTIONS = global_options.PKG_DEFAULT_OPTIONS
 
 
-def global_add_c_prefix() -> None:
-    """
-    Include ``c`` as a prefix for the exponent value -2.
-
-    Has no effect if exponent value -2 is already mapped to a prefix
-    string. To modify this mapping, first use
-    :func:`global_reset_si_prefixes` or use :func:`set_global_defaults`.
-    """
-    set_global_defaults(add_c_prefix=True)
-
-
-def global_add_small_si_prefixes() -> None:
-    """
-    Include ``{-2: 'c', -1: 'd', +1: 'da', +2: 'h'}`` as prefix substitutions.
-
-    Note, if any of these exponent values are mapped, then that mapping
-    will NOT be overwritten. To modify existing mappings either first
-    use :func:`global_reset_si_prefixes` or use
-    :func:`set_global_defaults`.
-    """
-    set_global_defaults(add_small_si_prefixes=True)
-
-
-def global_add_ppth_form() -> None:
-    """
-    Include ``ppth`` as a "parts-per" form for the exponent value -3.
-
-    Has no effect if exponent value -3 is already mapped to a
-    "parts-per" format string. To modify this mapping, first use
-    :func:`global_reset_parts_per_forms` or use
-    :func:`set_global_defaults`.
-    """
-    set_global_defaults(add_ppth_form=True)
-
-
-def global_reset_si_prefixes() -> None:
-    """Clear all extra SI prefix mappings."""
-    set_global_defaults(extra_si_prefixes={})
-
-
-def global_reset_iec_prefixes() -> None:
-    """Clear all extra IEC prefix mappings."""
-    set_global_defaults(extra_iec_prefixes={})
-
-
-def global_reset_parts_per_forms() -> None:
-    """Clear all extra "parts-per" forms."""
-    set_global_defaults(extra_parts_per_forms={})
-
-
 class GlobalDefaultsContext:
     """
     Temporarily update global default options.

--- a/src/sciform/user_options.py
+++ b/src/sciform/user_options.py
@@ -181,8 +181,6 @@ class UserOptions:
             elif isinstance(value, str):
                 enum = key_to_enum_dict[key]
                 rendered_value = modes.mode_str_to_enum(value, enum)
-            elif isinstance(value, dict):
-                rendered_value = value.copy()
             else:
                 rendered_value = value
             kwargs[key] = rendered_value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,3 +72,21 @@ class TestConfig(unittest.TestCase):
         with GlobalDefaultsContext(add_ppth_form=True):
             self.assertEqual(formatter(num), "2.4 ppth")
         self.assertEqual(formatter(num), "2.4e-03")
+
+    def test_add_c_prefix_no_overwrite(self):
+        sform = Formatter(
+            exp_mode="scientific",
+            exp_format="prefix",
+            extra_si_prefixes={-2: "zzz"},
+            add_c_prefix=True,
+        )
+        self.assertEqual(sform(0.012), "1.2 zzz")
+
+    def test_global_add_c_prefix_no_overwrite(self):
+        sform = Formatter(
+            exp_mode="scientific",
+            exp_format="prefix",
+            extra_si_prefixes={-4: "zzz"},
+        )
+        with GlobalDefaultsContext(add_c_prefix=True):
+            self.assertEqual(sform(0.012), "1.2e-02")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,12 +4,6 @@ from sciform import (
     Formatter,
     GlobalDefaultsContext,
     SciNum,
-    global_add_c_prefix,
-    global_add_ppth_form,
-    global_add_small_si_prefixes,
-    global_reset_iec_prefixes,
-    global_reset_parts_per_forms,
-    global_reset_si_prefixes,
     reset_global_defaults,
     set_global_defaults,
 )
@@ -41,9 +35,8 @@ class TestConfig(unittest.TestCase):
         num = SciNum(123.456)
         fmt_spec = "ex-2p"
         self.assertEqual(f"{num:{fmt_spec}}", "12345.6e-02")
-        global_add_c_prefix()
-        self.assertEqual(f"{num:{fmt_spec}}", "12345.6 c")
-        global_reset_si_prefixes()
+        with GlobalDefaultsContext(add_c_prefix=True):
+            self.assertEqual(f"{num:{fmt_spec}}", "12345.6 c")
         self.assertEqual(f"{num:{fmt_spec}}", "12345.6e-02")
 
     def test_small_si_prefixes(self):
@@ -56,19 +49,17 @@ class TestConfig(unittest.TestCase):
             +2: "1.23456 h",
         }
 
-        global_add_small_si_prefixes()
-        for exp, expected_num_str in cases_dict.items():
-            num_str = f"{num:ex{exp:+}p}"
-            self.assertEqual(num_str, expected_num_str)
-        global_reset_si_prefixes()
+        with GlobalDefaultsContext(add_small_si_prefixes=True):
+            for exp, expected_num_str in cases_dict.items():
+                num_str = f"{num:ex{exp:+}p}"
+                self.assertEqual(num_str, expected_num_str)
 
     def test_iec_prefix(self):
         num = SciNum(1024)
         fmt_spec = "bp"
         self.assertEqual(f"{num:{fmt_spec}}", "1 Ki")
-        set_global_defaults(extra_iec_prefixes={10: "KiB"})
-        self.assertEqual(f"{num:{fmt_spec}}", "1 KiB")
-        global_reset_iec_prefixes()
+        with GlobalDefaultsContext(extra_iec_prefixes={10: "KiB"}):
+            self.assertEqual(f"{num:{fmt_spec}}", "1 KiB")
         self.assertEqual(f"{num:{fmt_spec}}", "1 Ki")
 
     def test_ppth_form(self):
@@ -78,7 +69,6 @@ class TestConfig(unittest.TestCase):
             exp_format="parts_per",
         )
         self.assertEqual(formatter(num), "2.4e-03")
-        global_add_ppth_form()
-        self.assertEqual(formatter(num), "2.4 ppth")
-        global_reset_parts_per_forms()
+        with GlobalDefaultsContext(add_ppth_form=True):
+            self.assertEqual(formatter(num), "2.4 ppth")
         self.assertEqual(formatter(num), "2.4e-03")

--- a/tests/test_invalid_options.py
+++ b/tests/test_invalid_options.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 
 from sciform import Formatter, modes
 from sciform.format_utils import (
-    get_exp_str,
     get_mantissa_exp_base,
     get_prefix_dict,
     get_round_digit,
@@ -199,23 +198,6 @@ class TestInvalidOptions(unittest.TestCase):
             num=Decimal(3),
             exp_mode="eng",
             input_exp=3,
-        )
-
-    @unittest.expectedFailure  # This test can be removed now
-    def test_get_exp_str_bad_exp_mode(self):
-        self.assertRaises(
-            ValueError,
-            get_exp_str,
-            exp_val=2,
-            exp_mode="sci",
-            exp_format=modes.ExpFormat.STANDARD,
-            capitalize=False,
-            latex=False,
-            latex_trim_whitespace=False,
-            superscript=False,
-            extra_si_prefixes={},
-            extra_iec_prefixes={},
-            extra_parts_per_forms={},
         )
 
     def test_get_sign_str_bad_sign_mode(self):


### PR DESCRIPTION
Resolves https://github.com/jagerber48/sciform/issues/97

In the end this clarification ended up simply being the removal of 
```
global_add_c_prefix
global_add_ppth_form
global_add_small_si_prefixes
global_reset_iec_prefixes
global_reset_parts_per_forms
global_reset_si_prefixes
```
and some additional documentation and tests making the expected behavior more clear.