### PR TITLE
Feature/fixed width formatter 133

### DIFF
--- a/src/sciform/__init__.py
+++ b/src/sciform/__init__.py
@@ -9,9 +9,11 @@ from sciform.global_configuration import (
 )
 from sciform.modes import AutoDigits, AutoExpVal
 from sciform.scinum import SciNum
+from sciform.target_length import format_to_target_length
 
 __all__ = [
     "Formatter",
+    "format_to_target_length",
     "GlobalDefaultsContext",
     "print_global_defaults",
     "reset_global_defaults",

--- a/src/sciform/formatting.py
+++ b/src/sciform/formatting.py
@@ -175,6 +175,7 @@ def format_val_unc(val: Decimal, unc: Decimal, options: RenderedOptions) -> str:
         """
         exp_mode = ExpModeEnum.FIXEDPOINT
 
+    # TODO: Fix this comment
     """
     We round twice in case the first rounding changes the digits place
     to which we need to round. E.g. rounding 999.999 ± 123.456 to two

--- a/src/sciform/target_length.py
+++ b/src/sciform/target_length.py
@@ -9,13 +9,13 @@ from sciform.formatter import Formatter
 
 
 def format_to_target_length(
-        value: Number,
-        uncertainty: Number = None,
-        /,
-        *,
-        target_length: int,
-        allowed_exp_modes: Sequence[modes.ExpMode] = ("fixed_point",),
-        base_formatter: Formatter = None,
+    value: Number,
+    uncertainty: Number = None,
+    /,
+    *,
+    target_length: int,
+    allowed_exp_modes: Sequence[modes.ExpMode] = ("fixed_point",),
+    base_formatter: Formatter = None,
 ) -> str:
     """
     Format a number while adjusting sig_figs so that the result is a target length.

--- a/src/sciform/target_length.py
+++ b/src/sciform/target_length.py
@@ -1,0 +1,112 @@
+"""Formatting utilities to target fixed overall string length."""
+
+from dataclasses import asdict
+from typing import Sequence
+
+from sciform import modes
+from sciform.format_utils import Number
+from sciform.formatter import Formatter
+
+
+def format_to_target_length(
+        value: Number,
+        uncertainty: Number = None,
+        /,
+        *,
+        target_length: int,
+        allowed_exp_modes: Sequence[modes.ExpMode] = ("fixed_point",),
+        base_formatter: Formatter = None,
+) -> str:
+    """
+    Format a number while adjusting sig_figs so that the result is a target length.
+
+    :param value: (positional only) Value to be formatted.
+    :type value: ``Decimal | float | int | str``
+    :param uncertainty: (positional only) Optional uncertainty to be
+      formatted.
+    :type uncertainty: ``Decimal | float | int | str | None``
+    :param target_length: (keyword only) Integer number of characters to
+      target for output string. The output string will have a number of
+      characters at least as large as target_length. However, in some
+      cases, the output string must have a length exceeding
+      target_length. E.g. 123456789 cannot be displayed with less than 9
+      characters in fixed_point mode.
+    :type target_length: ``int``
+    :param allowed_exp_modes: (keyword only) Sequence of ``sciform``
+      exponent modes. ``format_to_target_length()`` will attempt
+      formatting using each of these modes and will select the mode
+      which provides the best result. The best result is the one with
+      the shortest length >= target_length. If there is a tie for
+      shortest length then results with more significant figures are
+      preferred. If there is still a tie then ``exp_modes`` which appear
+      earlier in the ``allowed_exp_modes`` sequence are preferred. By
+      default, only the ``"fixed_point"`` is allowed.
+    :type allowed_exp_modes: ``Sequence[Literal["fixed_point", "percent",
+          "scientific", "engineering", "engineering_shifted", "binary",
+          "binary_iec"]]``
+    :param base_formatter: (keyword only) Formatter object to use to
+      format the input number(s). The ``round_mode`` will be overridden
+      to ``"sig_fig"``, the ``exp_mode`` will be overridden to the values
+      in ``allowed_exp_modes`` and the ``num_sig_figs`` will be
+      overridden. If no base_formatter is supplied than a new
+      ``Formatter()`` instance is created which uses the global
+      ``sciform`` settings.
+    :type base_formatter: ``Formatter``
+    """
+    """
+    result_array is a list of tuples where each tuple is of the form
+    (length, -num_sig_figs, exp_mode_number, result_str)
+    At the end of the algorithm this list will be sorted and the
+    result_str of the first entry will be returned. Only entries with
+    length >= target_length will be included in this array. The sorting
+    will prefer the shortest string with the most sig figs. If there is
+    a tie then exponent modes with a lower exp_mode_number (the
+    corresponding index for that exp_mode in allowed_exp_modes sequence)
+    will be preferred.
+    """
+    result_array = []
+
+    if base_formatter is None:
+        base_formatter = Formatter()
+
+    input_kwargs = asdict(base_formatter._user_options)  # noqa: SLF001
+
+    best_length = float("inf")
+    best_sig_figs = 1
+    for idx, exp_mode in enumerate(allowed_exp_modes):
+        num_sig_figs = 1
+        while True:
+            # TODO: For large target_length the formatting throws a Decimal module error
+            #   which arises due to rounding beyond the specified Decimal precision.
+            #   This could be worked around by performing formatting in a local Decimal
+            #   context with a precision which expands as necessary when large numbers
+            #   of sig figs are requested.
+            kwargs = input_kwargs.copy()
+            kwargs["round_mode"] = "sig_fig"
+            kwargs["exp_mode"] = exp_mode
+            kwargs["ndigits"] = num_sig_figs
+
+            formatter = Formatter(**kwargs)
+            result = formatter(value, uncertainty)
+            length = len(result)
+
+            if length >= target_length:
+                if length <= best_length and num_sig_figs >= best_sig_figs:
+                    # Only include results which are improvements over previous results.
+                    best_length = length
+                    best_sig_figs = num_sig_figs
+                    """
+                    Use -num_sig_figs instead of num_sig_figs as a hack so that sort
+                    prefers more (rather than less) sig figs!
+                    """
+                    result_tuple = (length, -num_sig_figs, idx, result)
+                    result_array.append(result_tuple)
+                break
+
+            num_sig_figs += 1
+
+    sorted_results = sorted(result_array)
+    best_result_tuple = sorted_results[0]
+    best_result_str = best_result_tuple[3]
+
+    return best_result_str

--- a/tests/test_target_length.py
+++ b/tests/test_target_length.py
@@ -8,13 +8,13 @@ from sciform import Formatter, format_to_target_length, modes
 
 class TestFormatToTargetLength(unittest.TestCase):
     def run_val_cases(
-            self,
-            cases: list[tuple[tuple[float, float | None], str]],
-            *,
-            target_length: int,
-            allowed_exp_modes: Sequence[modes.ExpMode],
-            base_formatter: Formatter | None,
-            ):
+        self,
+        cases: list[tuple[tuple[float, float | None], str]],
+        *,
+        target_length: int,
+        allowed_exp_modes: Sequence[modes.ExpMode],
+        base_formatter: Formatter | None,
+    ):
         for (val, unc), expected_str in cases:
             with self.subTest(
                 val=val,

--- a/tests/test_target_length.py
+++ b/tests/test_target_length.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import unittest
+from typing import Sequence
+
+from sciform import Formatter, format_to_target_length, modes
+
+
+class TestFormatToTargetLength(unittest.TestCase):
+    def run_val_cases(
+            self,
+            cases: list[tuple[tuple[float, float | None], str]],
+            *,
+            target_length: int,
+            allowed_exp_modes: Sequence[modes.ExpMode],
+            base_formatter: Formatter | None,
+            ):
+        for (val, unc), expected_str in cases:
+            with self.subTest(
+                val=val,
+                expected_str=expected_str,
+            ):
+                actual_str = format_to_target_length(
+                    val,
+                    unc,
+                    target_length=target_length,
+                    allowed_exp_modes=allowed_exp_modes,
+                    base_formatter=base_formatter,
+                )
+                self.assertEqual(actual_str, expected_str)
+
+    def test_cases(self):
+        cases = [
+            (
+                (11301.3646429824, None),
+                "11301.3646",
+            ),
+            (
+                (7.55438813238573, None),
+                "7.55438813",
+            ),
+            (
+                (3037.18756328971, None),
+                "3037.18756",
+            ),
+            (
+                (3058.4404411981735, None),
+                "3058.44044",
+            ),
+            (
+                (13.8904759429872987, None),
+                "13.8904759",
+            ),
+            (
+                (5.440263872938719, None),
+                "5.44026387",
+            ),
+            (
+                (0.124643890130481, None),
+                "0.12464389",
+            ),
+            (
+                (0.009963634432798437298, None),
+                "0.00996363",
+            ),
+            (
+                (0.2441075332894732, None),
+                "0.24410753",
+            ),
+            (
+                (0.0141610629879, None),
+                "0.01416106",
+            ),
+            (
+                (0.0241421029837978, None),
+                "0.02414210",
+            ),
+            (
+                (0.0002027524899875, None),
+                "0.00020275",
+            ),
+            (
+                (0.00002027524899875, None),
+                "2.0275e-05",
+            ),
+        ]
+
+        self.run_val_cases(
+            cases,
+            target_length=10,
+            allowed_exp_modes=["fixed_point", "scientific"],
+            base_formatter=None,
+        )
+
+    def test_lmfit_gformat_data(self):
+        test_data_gformat = [
+            (-1.25, "-1.25000000"),
+            (1.25, " 1.25000000"),
+            (-1234567890.1234567890, "-1.2346e+09"),
+            (1234567890.1234567890, " 1.2346e+09"),
+            (12345.67890e150, " 1.235e+154"),
+        ]
+
+        for val, expected_str in test_data_gformat:
+            with self.subTest(
+                val=val,
+                expected_str=expected_str,
+            ):
+                result_str = format_to_target_length(
+                    val,
+                    target_length=11,
+                    allowed_exp_modes=["fixed_point", "scientific"],
+                    base_formatter=Formatter(sign_mode=" "),
+                )
+                self.assertEqual(result_str, expected_str)


### PR DESCRIPTION
Add formatting utilities to output strings will better controlled lengths as strings.

Until this point `sciform` has provided functionality to control

* The number of digits to the left of the most significant digit using `left_pad` options
* The number of digits to the right of the most signficiant digit using `round_mode="sig_fig"` and `ndigits`
* The number of digits to the right of the decimal symbol using `round_mode="dec_place"` and `ndigits`.

`format_to_target_length` applies an algorithm that varies the number of significant digits displayed and finds the best formatted result. Results closest to the target length are preferred.